### PR TITLE
Add backend modules: ik-common, ik-mat, and ik-alkohol with initial P…

### DIFF
--- a/backend/ik-alkohol/pom.xml
+++ b/backend/ik-alkohol/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.iksystem</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>ik-alkohol</artifactId>
+    <name>ik-alkohol</name>
+    <description>IK-Alkohol service module</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.iksystem</groupId>
+            <artifactId>ik-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/ik-alkohol/src/main/java/com/iksystem/ik_alkohol/IkAlkoholApplication.java
+++ b/backend/ik-alkohol/src/main/java/com/iksystem/ik_alkohol/IkAlkoholApplication.java
@@ -1,0 +1,12 @@
+package main.java.com.iksystem.ik_alkohol;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class IkAlkoholApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(IkAlkoholApplication.class, args);
+    }
+}

--- a/backend/ik-alkohol/src/test/java/com/iksystem/ik_alkohol/IkAlkoholApplicationTests.java
+++ b/backend/ik-alkohol/src/test/java/com/iksystem/ik_alkohol/IkAlkoholApplicationTests.java
@@ -1,0 +1,12 @@
+package test.java.com.iksystem.ik_alkohol;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class IkAlkoholApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/backend/ik-common/pom.xml
+++ b/backend/ik-common/pom.xml
@@ -3,12 +3,11 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.12</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<groupId>com.iksystem</groupId>
+		<artifactId>backend</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
-	<groupId>com.iksystem</groupId>
 	<artifactId>ik-common</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name/>
@@ -26,9 +25,6 @@
 		<tag/>
 		<url/>
 	</scm>
-	<properties>
-		<java.version>21</java.version>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/backend/ik-mat/pom.xml
+++ b/backend/ik-mat/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.iksystem</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>ik-mat</artifactId>
+    <name>ik-mat</name>
+    <description>IK-Mat service module</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.iksystem</groupId>
+            <artifactId>ik-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/ik-mat/src/main/java/com/iksystem/ik_mat/IkMatApplication.java
+++ b/backend/ik-mat/src/main/java/com/iksystem/ik_mat/IkMatApplication.java
@@ -1,0 +1,12 @@
+package main.java.com.iksystem.ik_mat;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class IkMatApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(IkMatApplication.class, args);
+    }
+}

--- a/backend/ik-mat/src/test/java/com/iksystem/ik_mat/IkMatApplicationTests.java
+++ b/backend/ik-mat/src/test/java/com/iksystem/ik_mat/IkMatApplicationTests.java
@@ -1,0 +1,12 @@
+package test.java.com.iksystem.ik_mat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class IkMatApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.12</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.iksystem</groupId>
+    <artifactId>backend</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>backend</name>
+    <description>IK System backend multi-module parent</description>
+
+    <modules>
+        <module>ik-common</module>
+        <module>ik-mat</module>
+        <module>ik-alkohol</module>
+    </modules>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+</project>


### PR DESCRIPTION
This pull request introduces a new multi-module Maven project structure for the backend, splitting the application into separate modules for common functionality, food services, and alcohol services. It establishes a shared parent POM and configures each module for Spring Boot development and testing.

Project structure and module setup:

* Added a new parent POM `backend/pom.xml` to manage common configuration, dependencies, and Java version for all backend modules, and to define `ik-common`, `ik-mat`, and `ik-alkohol` as submodules.
* Added module-specific POM files for `ik-mat` and `ik-alkohol`, each inheriting from the new parent POM and including dependencies on `ik-common` and Spring Boot starters for web and testing. [[1]](diffhunk://#diff-c2a2b4d5d135aa515e9d61ed07f839c906599d21b27edb6a619d3f31d3fd452cR1-R45) [[2]](diffhunk://#diff-f472f4c00d4304f962e6e341a38815631a603240bc81af29cf20013cd41963a8R1-R45)
* Updated `ik-common/pom.xml` to inherit from the new `backend` parent POM instead of the Spring Boot starter parent, and removed the Java version property (now defined in the parent). [[1]](diffhunk://#diff-4f844afaa51683d55d60bf46fe411a5f5018e6fb5bb02549613de46083f916b9L6-R10) [[2]](diffhunk://#diff-4f844afaa51683d55d60bf46fe411a5f5018e6fb5bb02549613de46083f916b9L29-L31)

Spring Boot application and test scaffolding:

* Added initial Spring Boot application classes and basic context load tests for both `ik-mat` and `ik-alkohol` modules. [[1]](diffhunk://#diff-b63b86c9264efbb2a0b219d2c27cf1668c40b5da2df1ce498fccd143a9cc269bR1-R12) [[2]](diffhunk://#diff-9fcbb347db7e3231cc86e38caaa2710d713674a897ee5840e19255468fbf576dR1-R12) [[3]](diffhunk://#diff-93875e2d5e3845d4d5261dd1c7f39157f3807d4b0a9151c5bac853eacb9f40d6R1-R12) [[4]](diffhunk://#diff-df6c01c3f9a3d59b96410f2ed45bcb85977ff711925982b0208adbe3530cd94eR1-R12)