### PR TITLE
created unit test for all the auth, user and organization features

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -115,6 +115,24 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-runner-junit5-jvm</artifactId>
+            <version>5.9.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
+            <version>5.9.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk-jvm</artifactId>
+            <version>1.13.13</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/test/kotlin/com/iksystem/ik-common/auth/service/AuthServiceTest.kt
+++ b/backend/src/test/kotlin/com/iksystem/ik-common/auth/service/AuthServiceTest.kt
@@ -1,0 +1,240 @@
+package com.iksystem.`ik-common`.auth.service
+
+import com.ik.ikcommon.exception.ConflictException
+import com.ik.ikcommon.exception.ForbiddenException
+import com.ik.ikcommon.exception.NotFoundException
+import com.ik.ikcommon.exception.UnauthorizedException
+import com.iksystem.`ik-common`.auth.dto.LoginRequest
+import com.iksystem.`ik-common`.auth.dto.RefreshRequest
+import com.iksystem.`ik-common`.auth.dto.RegisterRequest
+import com.iksystem.`ik-common`.auth.dto.SelectOrgRequest
+import com.iksystem.`ik-common`.membership.model.Membership
+import com.iksystem.`ik-common`.membership.repository.MembershipRepository
+import com.iksystem.`ik-common`.organization.model.Organization
+import com.iksystem.`ik-common`.security.JwtService
+import com.iksystem.`ik-common`.session.repository.SessionRepository
+import com.iksystem.`ik-common`.token.model.RefreshToken
+import com.iksystem.`ik-common`.token.repository.RefreshTokenRepository
+import com.iksystem.`ik-common`.user.model.Role
+import com.iksystem.`ik-common`.user.model.User
+import com.iksystem.`ik-common`.user.repository.UserRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeBlank
+import io.mockk.*
+import org.springframework.security.crypto.password.PasswordEncoder
+import java.time.Instant
+import java.util.*
+
+class AuthServiceTest : FunSpec({
+
+    val userRepository = mockk<UserRepository>()
+    val membershipRepository = mockk<MembershipRepository>()
+    val refreshTokenRepository = mockk<RefreshTokenRepository>()
+    val sessionRepository = mockk<SessionRepository>()
+    val jwtService = mockk<JwtService>()
+    val passwordEncoder = mockk<PasswordEncoder>()
+
+    val service = AuthService(
+        userRepository = userRepository,
+        membershipRepository = membershipRepository,
+        refreshTokenRepository = refreshTokenRepository,
+        sessionRepository = sessionRepository,
+        jwtService = jwtService,
+        passwordEncoder = passwordEncoder,
+        accessTokenExpiration = 900_000L,
+        refreshTokenExpiration = 604_800_000L,
+    )
+
+    val org = Organization(id = 1L, name = "Test Org", orgNumber = "123")
+    val user = User(id = 1L, email = "test@example.com", password = "hashed", fullName = "Test User", phoneNumber = "+47123")
+    val membership = Membership(id = 1L, user = user, organization = org, role = Role.ADMIN)
+
+    beforeTest {
+        clearMocks(userRepository, membershipRepository, refreshTokenRepository, sessionRepository, jwtService, passwordEncoder)
+    }
+
+    test("register creates user and returns pre-auth token") {
+        val request = RegisterRequest(email = "new@example.com", password = "password1", fullName = "New User", phoneNumber = "+47999")
+        every { userRepository.existsByEmail("new@example.com") } returns false
+        every { passwordEncoder.encode("password1") } returns "hashed"
+        every { userRepository.save(any()) } answers { firstArg<User>().copy(id = 2L) }
+        every { jwtService.generatePreAuthToken(any()) } returns "pre-auth-jwt"
+
+        val result = service.register(request)
+
+        result.preAuthToken shouldBe "pre-auth-jwt"
+        result.user.email shouldBe "new@example.com"
+        result.memberships.shouldBeEmpty()
+    }
+
+    test("register throws ConflictException for duplicate email") {
+        val request = RegisterRequest(email = "existing@example.com", password = "password1", fullName = "User", phoneNumber = "+47000")
+        every { userRepository.existsByEmail("existing@example.com") } returns true
+
+        shouldThrow<ConflictException> {
+            service.register(request)
+        }.message shouldBe "Email already registered"
+    }
+
+    test("login returns pre-auth token and memberships") {
+        val request = LoginRequest(email = "test@example.com", password = "password1")
+        every { userRepository.findByEmail("test@example.com") } returns user
+        every { passwordEncoder.matches("password1", "hashed") } returns true
+        every { membershipRepository.findAllByUserId(1L) } returns listOf(membership)
+        every { jwtService.generatePreAuthToken(user) } returns "pre-auth-jwt"
+
+        val result = service.login(request)
+
+        result.preAuthToken shouldBe "pre-auth-jwt"
+        result.memberships shouldHaveSize 1
+        result.memberships[0].organizationName shouldBe "Test Org"
+    }
+
+    test("login throws for unknown email") {
+        every { userRepository.findByEmail("unknown@example.com") } returns null
+
+        shouldThrow<UnauthorizedException> {
+            service.login(LoginRequest("unknown@example.com", "pass"))
+        }
+    }
+
+    test("login throws for wrong password") {
+        every { userRepository.findByEmail("test@example.com") } returns user
+        every { passwordEncoder.matches("wrong", "hashed") } returns false
+
+        shouldThrow<UnauthorizedException> {
+            service.login(LoginRequest("test@example.com", "wrong"))
+        }
+    }
+
+    test("login throws for deactivated account") {
+        val inactive = user.copy(active = false)
+        every { userRepository.findByEmail("test@example.com") } returns inactive
+
+        shouldThrow<UnauthorizedException> {
+            service.login(LoginRequest("test@example.com", "password1"))
+        }.message shouldBe "Account is deactivated"
+    }
+
+    test("selectOrg returns full auth response") {
+        every { userRepository.findById(1L) } returns Optional.of(user)
+        every { membershipRepository.findByUserIdAndOrganizationId(1L, 1L) } returns membership
+        every { jwtService.generateAccessToken(user, membership) } returns "access-jwt"
+        every { refreshTokenRepository.save(any()) } answers { firstArg() }
+        every { sessionRepository.save(any()) } answers { firstArg() }
+
+        val result = service.selectOrg(1L, SelectOrgRequest(1L), "127.0.0.1", "Mozilla")
+
+        result.accessToken shouldBe "access-jwt"
+        result.refreshToken.shouldNotBeBlank()
+        result.role shouldBe "ADMIN"
+        result.organizationId shouldBe 1L
+    }
+
+    test("selectOrg throws for non-member") {
+        every { userRepository.findById(1L) } returns Optional.of(user)
+        every { membershipRepository.findByUserIdAndOrganizationId(1L, 99L) } returns null
+
+        shouldThrow<ForbiddenException> {
+            service.selectOrg(1L, SelectOrgRequest(99L), null, null)
+        }
+    }
+
+    test("selectOrg throws for deactivated user") {
+        val inactive = user.copy(active = false)
+        every { userRepository.findById(1L) } returns Optional.of(inactive)
+
+        shouldThrow<UnauthorizedException> {
+            service.selectOrg(1L, SelectOrgRequest(1L), null, null)
+        }
+    }
+
+    test("refresh rotates token and returns new auth response") {
+        val storedToken = RefreshToken(
+            id = 1L, token = "old-refresh", user = user,
+            organizationId = 1L, expiresAt = Instant.now().plusSeconds(3600),
+        )
+        every { refreshTokenRepository.findByToken("old-refresh") } returns storedToken
+        every { membershipRepository.findByUserIdAndOrganizationId(1L, 1L) } returns membership
+        every { refreshTokenRepository.save(any()) } answers { firstArg() }
+        every { sessionRepository.save(any()) } answers { firstArg() }
+        every { jwtService.generateAccessToken(user, membership) } returns "new-access-jwt"
+
+        val result = service.refresh(RefreshRequest("old-refresh"))
+
+        result.accessToken shouldBe "new-access-jwt"
+        verify { refreshTokenRepository.save(match { it.revoked }) }
+    }
+
+    test("refresh throws for invalid token") {
+        every { refreshTokenRepository.findByToken("bad-token") } returns null
+
+        shouldThrow<UnauthorizedException> {
+            service.refresh(RefreshRequest("bad-token"))
+        }
+    }
+
+    test("refresh throws for expired token") {
+        val expired = RefreshToken(
+            id = 1L, token = "expired", user = user,
+            organizationId = 1L, expiresAt = Instant.now().minusSeconds(3600),
+        )
+        every { refreshTokenRepository.findByToken("expired") } returns expired
+
+        shouldThrow<UnauthorizedException> {
+            service.refresh(RefreshRequest("expired"))
+        }
+    }
+
+    test("refresh throws for revoked token") {
+        val revoked = RefreshToken(
+            id = 1L, token = "revoked", user = user,
+            organizationId = 1L, expiresAt = Instant.now().plusSeconds(3600), revoked = true,
+        )
+        every { refreshTokenRepository.findByToken("revoked") } returns revoked
+
+        shouldThrow<UnauthorizedException> {
+            service.refresh(RefreshRequest("revoked"))
+        }
+    }
+
+    test("switchOrg revokes old org tokens and issues new ones") {
+        every { userRepository.findById(1L) } returns Optional.of(user)
+        every { membershipRepository.findByUserIdAndOrganizationId(1L, 2L) } returns membership.copy(id = 2L)
+        every { refreshTokenRepository.revokeAllByUserIdAndOrganizationId(1L, 1L) } just runs
+        every { sessionRepository.deactivateAllByUserIdAndOrganizationId(1L, 1L) } just runs
+        every { jwtService.generateAccessToken(any(), any()) } returns "new-org-jwt"
+        every { refreshTokenRepository.save(any()) } answers { firstArg() }
+        every { sessionRepository.save(any()) } answers { firstArg() }
+
+        val result = service.switchOrg(1L, 1L, SelectOrgRequest(2L), null, null)
+
+        result.accessToken shouldBe "new-org-jwt"
+        verify { refreshTokenRepository.revokeAllByUserIdAndOrganizationId(1L, 1L) }
+        verify { sessionRepository.deactivateAllByUserIdAndOrganizationId(1L, 1L) }
+    }
+
+    test("logout revokes all tokens and sessions") {
+        every { refreshTokenRepository.revokeAllByUserId(1L) } just runs
+        every { sessionRepository.deactivateAllByUserId(1L) } just runs
+
+        service.logout(1L)
+
+        verify { refreshTokenRepository.revokeAllByUserId(1L) }
+        verify { sessionRepository.deactivateAllByUserId(1L) }
+    }
+
+    test("listMemberships returns summaries") {
+        every { membershipRepository.findAllByUserId(1L) } returns listOf(membership)
+
+        val result = service.listMemberships(1L)
+
+        result shouldHaveSize 1
+        result[0].organizationName shouldBe "Test Org"
+        result[0].role shouldBe "ADMIN"
+    }
+})

--- a/backend/src/test/kotlin/com/iksystem/ik-common/organization/service/OrganizationServiceTest.kt
+++ b/backend/src/test/kotlin/com/iksystem/ik-common/organization/service/OrganizationServiceTest.kt
@@ -1,0 +1,113 @@
+package com.iksystem.`ik-common`.organization.service
+
+import com.ik.ikcommon.exception.ConflictException
+import com.ik.ikcommon.exception.NotFoundException
+import com.iksystem.`ik-common`.membership.model.Membership
+import com.iksystem.`ik-common`.membership.repository.MembershipRepository
+import com.iksystem.`ik-common`.organization.dto.CreateOrganizationRequest
+import com.iksystem.`ik-common`.organization.model.Organization
+import com.iksystem.`ik-common`.organization.repository.OrganizationRepository
+import com.iksystem.`ik-common`.user.model.Role
+import com.iksystem.`ik-common`.user.model.User
+import com.iksystem.`ik-common`.user.repository.UserRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.*
+import java.util.*
+
+class OrganizationServiceTest : FunSpec({
+
+    val organizationRepository = mockk<OrganizationRepository>()
+    val membershipRepository = mockk<MembershipRepository>()
+    val userRepository = mockk<UserRepository>()
+
+    val service = OrganizationService(
+        organizationRepository = organizationRepository,
+        membershipRepository = membershipRepository,
+        userRepository = userRepository,
+    )
+
+    val user = User(id = 1L, email = "test@example.com", password = "hashed", fullName = "Test User", phoneNumber = "+47123")
+    val org = Organization(id = 1L, name = "Test Org", orgNumber = "123456")
+
+    beforeTest {
+        clearMocks(organizationRepository, membershipRepository, userRepository)
+    }
+
+    test("create saves org and makes caller ADMIN") {
+        val request = CreateOrganizationRequest(name = "New Org", orgNumber = "999")
+        every { organizationRepository.existsByName("New Org") } returns false
+        every { organizationRepository.save(any()) } returns org.copy(name = "New Org")
+        every { userRepository.findById(1L) } returns Optional.of(user)
+        every { membershipRepository.save(any()) } answers { firstArg() }
+
+        val result = service.create(request, 1L)
+
+        result.name shouldBe "New Org"
+        verify { membershipRepository.save(match { it.role == Role.ADMIN && it.user == user }) }
+    }
+
+    test("create throws ConflictException for duplicate name") {
+        every { organizationRepository.existsByName("Test Org") } returns true
+
+        shouldThrow<ConflictException> {
+            service.create(CreateOrganizationRequest(name = "Test Org"), 1L)
+        }
+    }
+
+    test("create throws NotFoundException for unknown user") {
+        every { organizationRepository.existsByName("New Org") } returns false
+        every { organizationRepository.save(any()) } returns org
+        every { userRepository.findById(99L) } returns Optional.empty()
+
+        shouldThrow<NotFoundException> {
+            service.create(CreateOrganizationRequest(name = "New Org"), 99L)
+        }
+    }
+
+    test("getById returns organization") {
+        every { organizationRepository.findById(1L) } returns Optional.of(org)
+
+        val result = service.getById(1L)
+
+        result.id shouldBe 1L
+        result.name shouldBe "Test Org"
+        result.orgNumber shouldBe "123456"
+    }
+
+    test("getById throws NotFoundException for unknown id") {
+        every { organizationRepository.findById(99L) } returns Optional.empty()
+
+        shouldThrow<NotFoundException> {
+            service.getById(99L)
+        }
+    }
+
+    test("listAll returns all organizations") {
+        val org2 = Organization(id = 2L, name = "Other Org")
+        every { organizationRepository.findAll() } returns listOf(org, org2)
+
+        val result = service.listAll()
+
+        result shouldHaveSize 2
+    }
+
+    test("delete removes existing organization") {
+        every { organizationRepository.existsById(1L) } returns true
+        every { organizationRepository.deleteById(1L) } just runs
+
+        service.delete(1L)
+
+        verify { organizationRepository.deleteById(1L) }
+    }
+
+    test("delete throws NotFoundException for unknown id") {
+        every { organizationRepository.existsById(99L) } returns false
+
+        shouldThrow<NotFoundException> {
+            service.delete(99L)
+        }
+    }
+})

--- a/backend/src/test/kotlin/com/iksystem/ik-common/security/JwtServiceTest.kt
+++ b/backend/src/test/kotlin/com/iksystem/ik-common/security/JwtServiceTest.kt
@@ -1,0 +1,65 @@
+package com.iksystem.`ik-common`.security
+
+import com.iksystem.`ik-common`.membership.model.Membership
+import com.iksystem.`ik-common`.organization.model.Organization
+import com.iksystem.`ik-common`.user.model.Role
+import com.iksystem.`ik-common`.user.model.User
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class JwtServiceTest : FunSpec({
+
+    // 256-bit key for HMAC-SHA
+    val secret = "test-secret-key-that-must-be-at-least-256-bits-long-for-hmac-sha!!"
+    val jwtService = JwtService(secret = secret, accessTokenExpiration = 900_000L)
+
+    val user = User(id = 1L, email = "test@example.com", password = "hashed", fullName = "Test User", phoneNumber = "+47123")
+    val org = Organization(id = 1L, name = "Test Org")
+    val membership = Membership(id = 1L, user = user, organization = org, role = Role.ADMIN)
+
+    test("generatePreAuthToken creates valid token with pre_auth type") {
+        val token = jwtService.generatePreAuthToken(user)
+
+        val claims = jwtService.validateToken(token)
+        claims.shouldNotBeNull()
+        jwtService.getUserId(claims) shouldBe 1L
+        jwtService.getTokenType(claims) shouldBe "pre_auth"
+        jwtService.getRole(claims).shouldBeNull()
+        jwtService.getOrganizationId(claims).shouldBeNull()
+    }
+
+    test("generateAccessToken creates valid token with role and orgId") {
+        val token = jwtService.generateAccessToken(user, membership)
+
+        val claims = jwtService.validateToken(token)
+        claims.shouldNotBeNull()
+        jwtService.getUserId(claims) shouldBe 1L
+        jwtService.getTokenType(claims) shouldBe "access"
+        jwtService.getRole(claims) shouldBe "ADMIN"
+        jwtService.getOrganizationId(claims) shouldBe 1L
+    }
+
+    test("validateToken returns null for tampered token") {
+        val token = jwtService.generateAccessToken(user, membership)
+
+        val claims = jwtService.validateToken(token + "tampered")
+
+        claims.shouldBeNull()
+    }
+
+    test("validateToken returns null for garbage input") {
+        jwtService.validateToken("not.a.jwt").shouldBeNull()
+    }
+
+    test("validateToken returns null for token signed with different key") {
+        val otherService = JwtService(
+            secret = "different-secret-key-that-is-also-at-least-256-bits-long-for-hmac!!",
+            accessTokenExpiration = 900_000L,
+        )
+        val token = otherService.generateAccessToken(user, membership)
+
+        jwtService.validateToken(token).shouldBeNull()
+    }
+})

--- a/backend/src/test/kotlin/com/iksystem/ik-common/user/service/UserServiceTest.kt
+++ b/backend/src/test/kotlin/com/iksystem/ik-common/user/service/UserServiceTest.kt
@@ -1,0 +1,231 @@
+package com.iksystem.`ik-common`.user.service
+
+import com.ik.ikcommon.exception.BadRequestException
+import com.ik.ikcommon.exception.ConflictException
+import com.ik.ikcommon.exception.ForbiddenException
+import com.ik.ikcommon.exception.NotFoundException
+import com.iksystem.`ik-common`.membership.model.Membership
+import com.iksystem.`ik-common`.membership.repository.MembershipRepository
+import com.iksystem.`ik-common`.organization.model.Organization
+import com.iksystem.`ik-common`.organization.repository.OrganizationRepository
+import com.iksystem.`ik-common`.security.AuthenticatedUser
+import com.iksystem.`ik-common`.session.repository.SessionRepository
+import com.iksystem.`ik-common`.token.repository.RefreshTokenRepository
+import com.iksystem.`ik-common`.user.dto.CreateUserRequest
+import com.iksystem.`ik-common`.user.dto.UpdateUserRoleRequest
+import com.iksystem.`ik-common`.user.model.Role
+import com.iksystem.`ik-common`.user.model.User
+import com.iksystem.`ik-common`.user.repository.UserRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.*
+import org.springframework.security.crypto.password.PasswordEncoder
+import java.util.*
+
+class UserServiceTest : FunSpec({
+
+    val userRepository = mockk<UserRepository>()
+    val membershipRepository = mockk<MembershipRepository>()
+    val organizationRepository = mockk<OrganizationRepository>()
+    val refreshTokenRepository = mockk<RefreshTokenRepository>()
+    val sessionRepository = mockk<SessionRepository>()
+    val passwordEncoder = mockk<PasswordEncoder>()
+
+    val service = UserService(
+        userRepository = userRepository,
+        membershipRepository = membershipRepository,
+        organizationRepository = organizationRepository,
+        refreshTokenRepository = refreshTokenRepository,
+        sessionRepository = sessionRepository,
+        passwordEncoder = passwordEncoder,
+    )
+
+    val org = Organization(id = 1L, name = "Test Org", orgNumber = "123")
+    val user = User(id = 1L, email = "test@example.com", password = "hashed", fullName = "Test User", phoneNumber = "+47123")
+    val otherUser = User(id = 2L, email = "other@example.com", password = "hashed", fullName = "Other User", phoneNumber = "+47456")
+    val membership = Membership(id = 1L, user = user, organization = org, role = Role.ADMIN)
+    val otherMembership = Membership(id = 2L, user = otherUser, organization = org, role = Role.EMPLOYEE)
+    val auth = AuthenticatedUser(userId = 1L, organizationId = 1L, role = "ADMIN")
+
+    beforeTest {
+        clearMocks(userRepository, membershipRepository, organizationRepository, refreshTokenRepository, sessionRepository, passwordEncoder)
+    }
+
+    test("listUsers returns all memberships in org") {
+        every { membershipRepository.findAllByOrganizationId(1L) } returns listOf(membership, otherMembership)
+
+        val result = service.listUsers(auth)
+
+        result shouldHaveSize 2
+        result[0].userEmail shouldBe "test@example.com"
+        result[1].role shouldBe "EMPLOYEE"
+    }
+
+    test("getUser returns membership for user in org") {
+        every { membershipRepository.findByUserIdAndOrganizationId(2L, 1L) } returns otherMembership
+
+        val result = service.getUser(2L, auth)
+
+        result.userId shouldBe 2L
+        result.role shouldBe "EMPLOYEE"
+    }
+
+    test("getUser throws NotFoundException when user not in org") {
+        every { membershipRepository.findByUserIdAndOrganizationId(99L, 1L) } returns null
+
+        shouldThrow<NotFoundException> {
+            service.getUser(99L, auth)
+        }
+    }
+
+    test("getCurrentUser returns caller profile") {
+        every { userRepository.findById(1L) } returns Optional.of(user)
+
+        val result = service.getCurrentUser(auth)
+
+        result.email shouldBe "test@example.com"
+        result.fullName shouldBe "Test User"
+    }
+
+    test("createUser creates new user and membership") {
+        val request = CreateUserRequest(
+            email = "new@example.com", password = "password1",
+            fullName = "New User", phoneNumber = "+47789", role = "EMPLOYEE",
+        )
+        every { organizationRepository.findById(1L) } returns Optional.of(org)
+        every { userRepository.findByEmail("new@example.com") } returns null
+        every { passwordEncoder.encode("password1") } returns "hashed"
+        every { userRepository.save(any()) } answers { firstArg<User>().copy(id = 3L) }
+        every { membershipRepository.save(any()) } answers { firstArg<Membership>().copy(id = 3L) }
+
+        val result = service.createUser(request, auth)
+
+        result.role shouldBe "EMPLOYEE"
+        verify { userRepository.save(any()) }
+        verify { membershipRepository.save(any()) }
+    }
+
+    test("createUser adds existing user to org") {
+        val request = CreateUserRequest(
+            email = "other@example.com", password = "password1",
+            fullName = "Other User", phoneNumber = "+47456", role = "MANAGER",
+        )
+        every { organizationRepository.findById(1L) } returns Optional.of(org)
+        every { userRepository.findByEmail("other@example.com") } returns otherUser
+        every { membershipRepository.existsByUserIdAndOrganizationId(2L, 1L) } returns false
+        every { membershipRepository.save(any()) } answers { firstArg<Membership>().copy(id = 5L) }
+
+        val result = service.createUser(request, auth)
+
+        result.role shouldBe "MANAGER"
+        verify(exactly = 0) { userRepository.save(any()) }
+    }
+
+    test("createUser throws ConflictException if user already in org") {
+        val request = CreateUserRequest(
+            email = "other@example.com", password = "password1",
+            fullName = "Other User", phoneNumber = "+47456", role = "EMPLOYEE",
+        )
+        every { organizationRepository.findById(1L) } returns Optional.of(org)
+        every { userRepository.findByEmail("other@example.com") } returns otherUser
+        every { membershipRepository.existsByUserIdAndOrganizationId(2L, 1L) } returns true
+
+        shouldThrow<ConflictException> {
+            service.createUser(request, auth)
+        }
+    }
+
+    test("createUser throws BadRequestException for invalid role") {
+        val request = CreateUserRequest(
+            email = "new@example.com", password = "password1",
+            fullName = "New", phoneNumber = "+47000", role = "SUPERADMIN",
+        )
+        every { organizationRepository.findById(1L) } returns Optional.of(org)
+
+        shouldThrow<BadRequestException> {
+            service.createUser(request, auth)
+        }
+    }
+
+    test("updateUserRole changes role") {
+        every { membershipRepository.findByUserIdAndOrganizationId(2L, 1L) } returns otherMembership
+        every { membershipRepository.save(any()) } answers { firstArg() }
+
+        val result = service.updateUserRole(2L, UpdateUserRoleRequest("MANAGER"), auth)
+
+        result.role shouldBe "MANAGER"
+    }
+
+    test("deactivateUser sets active to false and revokes tokens") {
+        every { membershipRepository.findByUserIdAndOrganizationId(2L, 1L) } returns otherMembership
+        every { userRepository.findById(2L) } returns Optional.of(otherUser)
+        every { refreshTokenRepository.revokeAllByUserId(2L) } just runs
+        every { sessionRepository.deactivateAllByUserId(2L) } just runs
+        every { userRepository.save(any()) } answers { firstArg() }
+
+        val result = service.deactivateUser(2L, auth)
+
+        result.active shouldBe false
+        verify { refreshTokenRepository.revokeAllByUserId(2L) }
+    }
+
+    test("deactivateUser throws ForbiddenException for self-deactivation") {
+        every { membershipRepository.findByUserIdAndOrganizationId(1L, 1L) } returns membership
+
+        shouldThrow<ForbiddenException> {
+            service.deactivateUser(1L, auth)
+        }
+    }
+
+    test("activateUser sets active to true") {
+        val inactive = otherUser.copy(active = false)
+        every { membershipRepository.findByUserIdAndOrganizationId(2L, 1L) } returns otherMembership
+        every { userRepository.findById(2L) } returns Optional.of(inactive)
+        every { userRepository.save(any()) } answers { firstArg() }
+
+        val result = service.activateUser(2L, auth)
+
+        result.active shouldBe true
+    }
+
+    test("kickUser revokes sessions and tokens") {
+        every { membershipRepository.findByUserIdAndOrganizationId(2L, 1L) } returns otherMembership
+        every { refreshTokenRepository.revokeAllByUserId(2L) } just runs
+        every { sessionRepository.deactivateAllByUserId(2L) } just runs
+
+        service.kickUser(2L, auth)
+
+        verify { refreshTokenRepository.revokeAllByUserId(2L) }
+        verify { sessionRepository.deactivateAllByUserId(2L) }
+    }
+
+    test("kickUser throws ForbiddenException for self-kick") {
+        every { membershipRepository.findByUserIdAndOrganizationId(1L, 1L) } returns membership
+
+        shouldThrow<ForbiddenException> {
+            service.kickUser(1L, auth)
+        }
+    }
+
+    test("removeMember deletes membership and revokes org tokens") {
+        every { membershipRepository.findByUserIdAndOrganizationId(2L, 1L) } returns otherMembership
+        every { membershipRepository.delete(otherMembership) } just runs
+        every { refreshTokenRepository.revokeAllByUserIdAndOrganizationId(2L, 1L) } just runs
+        every { sessionRepository.deactivateAllByUserIdAndOrganizationId(2L, 1L) } just runs
+
+        service.removeMember(2L, auth)
+
+        verify { membershipRepository.delete(otherMembership) }
+        verify { refreshTokenRepository.revokeAllByUserIdAndOrganizationId(2L, 1L) }
+    }
+
+    test("removeMember throws ForbiddenException for self-removal") {
+        every { membershipRepository.findByUserIdAndOrganizationId(1L, 1L) } returns membership
+
+        shouldThrow<ForbiddenException> {
+            service.removeMember(1L, auth)
+        }
+    }
+})


### PR DESCRIPTION
This pull request adds comprehensive unit tests for key backend services and updates the test dependencies to support Kotlin-based testing. The main focus is on increasing test coverage and ensuring the reliability of authentication, organization management, and JWT handling logic.

**Testing infrastructure improvements:**

* Added `kotest` and `mockk` dependencies to `pom.xml` to enable expressive Kotlin-based testing and mocking in the backend.

**New unit tests for core services:**

* Added `AuthServiceTest.kt` to cover user registration, login, organization selection, token refresh, organization switching, logout, and membership listing, including error cases.
* Added `OrganizationServiceTest.kt` to test organization creation, retrieval, listing, and deletion, including edge cases such as duplicate names and missing users.
* Added `JwtServiceTest.kt` to verify JWT creation, validation, and claim extraction, as well as handling of invalid or tampered tokens.