### PR TITLE
refactor: remove closedAt field and update status handling in deviati…

### DIFF
--- a/backend/src/main/kotlin/com/iksystem/ik-common/deviation/dto/DeviationDtos.kt
+++ b/backend/src/main/kotlin/com/iksystem/ik-common/deviation/dto/DeviationDtos.kt
@@ -64,7 +64,6 @@ data class DeviationResponse(
     val assignedToUserName: String?,
     val reportedAt: String,
     val resolvedAt: String?,
-    val closedAt: String?,
     val createdAt: String,
     val updatedAt: String,
 )

--- a/backend/src/main/kotlin/com/iksystem/ik-common/deviation/model/Deviation.kt
+++ b/backend/src/main/kotlin/com/iksystem/ik-common/deviation/model/Deviation.kt
@@ -61,9 +61,6 @@ data class Deviation(
     @Column(name = "resolved_at")
     val resolvedAt: Instant? = null,
 
-    @Column(name = "closed_at")
-    val closedAt: Instant? = null,
-
     @Column(name = "created_at", nullable = false, updatable = false)
     val createdAt: Instant = Instant.now(),
 

--- a/backend/src/main/kotlin/com/iksystem/ik-common/deviation/model/DeviationStatus.kt
+++ b/backend/src/main/kotlin/com/iksystem/ik-common/deviation/model/DeviationStatus.kt
@@ -7,5 +7,4 @@ enum class DeviationStatus {
     OPEN,
     IN_PROGRESS,
     RESOLVED,
-    CLOSED,
 }

--- a/backend/src/main/kotlin/com/iksystem/ik-common/deviation/service/DeviationService.kt
+++ b/backend/src/main/kotlin/com/iksystem/ik-common/deviation/service/DeviationService.kt
@@ -107,12 +107,6 @@ class DeviationService(
 
         val resolvedAt = when (request.status) {
             DeviationStatus.RESOLVED -> existing.resolvedAt ?: now
-            DeviationStatus.CLOSED -> existing.resolvedAt ?: now
-            else -> null
-        }
-
-        val closedAt = when (request.status) {
-            DeviationStatus.CLOSED -> existing.closedAt ?: now
             else -> null
         }
 
@@ -120,7 +114,6 @@ class DeviationService(
             existing.copy(
                 status = request.status,
                 resolvedAt = resolvedAt,
-                closedAt = closedAt,
                 updatedAt = now,
             )
         )
@@ -175,7 +168,6 @@ private fun Deviation.toResponse(): DeviationResponse = DeviationResponse(
     assignedToUserName = assignedToUser?.fullName,
     reportedAt = reportedAt.toString(),
     resolvedAt = resolvedAt?.toString(),
-    closedAt = closedAt?.toString(),
     createdAt = createdAt.toString(),
     updatedAt = updatedAt.toString(),
 )

--- a/backend/src/main/resources/db/migration/V8__seed_deviations_data.sql
+++ b/backend/src/main/resources/db/migration/V8__seed_deviations_data.sql
@@ -9,8 +9,7 @@ INSERT INTO deviations (
     reported_by_user_id,
     assigned_to_user_id,
     reported_at,
-    resolved_at,
-    closed_at
+    resolved_at
 )
 VALUES
     (
@@ -24,7 +23,6 @@ VALUES
         (SELECT id FROM users WHERE email = 'employee@iksystem.local'),
         (SELECT id FROM users WHERE email = 'manager@iksystem.local'),
         DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 2 HOUR),
-        NULL,
         NULL
     ),
     (
@@ -38,7 +36,6 @@ VALUES
         (SELECT id FROM users WHERE email = 'manager@iksystem.local'),
         (SELECT id FROM users WHERE email = 'admin@iksystem.local'),
         DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 1 DAY),
-        NULL,
         NULL
     ),
     (
@@ -52,7 +49,6 @@ VALUES
         (SELECT id FROM users WHERE email = 'employee@iksystem.local'),
         (SELECT id FROM users WHERE email = 'manager@iksystem.local'),
         DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 2 DAY),
-        NULL,
         NULL
     ),
     (
@@ -66,8 +62,7 @@ VALUES
         (SELECT id FROM users WHERE email = 'employee@iksystem.local'),
         (SELECT id FROM users WHERE email = 'manager@iksystem.local'),
         DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 3 DAY),
-        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 2 DAY),
-        NULL
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 2 DAY)
     ),
     (
         (SELECT id FROM organizations WHERE name = 'Demo Organization'),
@@ -76,10 +71,9 @@ VALUES
         'Nyansatt har ikke fullført dokumentert opplaering i ansvarlig skjenking.',
         'Midlertidig omplassering til oppgaver uten alkoholservering.',
         'MEDIUM',
-        'CLOSED',
+        'RESOLVED',
         (SELECT id FROM users WHERE email = 'admin@iksystem.local'),
         (SELECT id FROM users WHERE email = 'admin@iksystem.local'),
         DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 5 DAY),
-        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 4 DAY),
-        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 3 DAY)
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 4 DAY)
     );

--- a/frontend/src/components/dashboard/KpiCard.vue
+++ b/frontend/src/components/dashboard/KpiCard.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 const props = withDefaults(
   defineProps<{
     title: string
@@ -17,10 +19,14 @@ const props = withDefaults(
   },
 )
 
-const progressPercent =
-  props.progress && props.progress.total > 0
-    ? Math.round((props.progress.current / props.progress.total) * 100)
-    : 0
+const progressPercent = computed(() => {
+  if (!props.progress || props.progress.total <= 0) {
+    return 0
+  }
+
+  const ratio = props.progress.current / props.progress.total
+  return Math.max(0, Math.min(100, Math.round(ratio * 100)))
+})
 </script>
 
 <template>

--- a/frontend/src/components/deviations/DeviationDetailsDialog.vue
+++ b/frontend/src/components/deviations/DeviationDetailsDialog.vue
@@ -45,7 +45,6 @@ const statusLabel: Record<DeviationStatus, string> = {
   OPEN: 'Åpen',
   IN_PROGRESS: 'Under behandling',
   RESOLVED: 'Løst',
-  CLOSED: 'Løst',
 }
 
 const severityLabel: Record<DeviationSeverity, string> = {
@@ -65,12 +64,8 @@ const severityTone: Record<DeviationSeverity, 'ok' | 'warning' | 'danger'> = {
 const availableStatuses: Array<{ value: DeviationStatus; label: string }> = [
   { value: 'OPEN', label: 'Åpen' },
   { value: 'IN_PROGRESS', label: 'Under behandling' },
-  { value: 'CLOSED', label: 'Løst' },
+  { value: 'RESOLVED', label: 'Løst' },
 ]
-
-function normalizedStatus(status: DeviationStatus): DeviationStatus {
-  return status === 'RESOLVED' ? 'CLOSED' : status
-}
 
 function onStatusClick(status: DeviationStatus) {
   if (!props.deviation) {
@@ -129,10 +124,6 @@ function onStatusClick(status: DeviationStatus) {
             <p>{{ deviation.resolvedAt ? new Date(deviation.resolvedAt).toLocaleString('nb-NO') : 'Ikke løst' }}</p>
           </div>
           <div>
-            <h4>Lukket</h4>
-            <p>{{ deviation.closedAt ? new Date(deviation.closedAt).toLocaleString('nb-NO') : 'Ikke lukket' }}</p>
-          </div>
-          <div>
             <h4>Sist oppdatert</h4>
             <p>{{ new Date(deviation.updatedAt).toLocaleString('nb-NO') }}</p>
           </div>
@@ -146,7 +137,7 @@ function onStatusClick(status: DeviationStatus) {
               :key="statusOption.value"
               type="button"
               class="status-button"
-              :class="{ 'status-button--active': normalizedStatus(deviation.status) === statusOption.value }"
+              :class="{ 'status-button--active': deviation.status === statusOption.value }"
               @click="onStatusClick(statusOption.value)"
             >
               {{ statusOption.label }}

--- a/frontend/src/components/deviations/DeviationListCard.vue
+++ b/frontend/src/components/deviations/DeviationListCard.vue
@@ -42,7 +42,6 @@ const statusLabel: Record<DeviationStatus, string> = {
   OPEN: 'Åpen',
   IN_PROGRESS: 'Under behandling',
   RESOLVED: 'Løst',
-  CLOSED: 'Løst',
 }
 
 const severityLabel: Record<DeviationSeverity, string> = {
@@ -63,7 +62,6 @@ const statusTone: Record<DeviationStatus, 'neutral' | 'ok' | 'danger' | 'warning
   OPEN: 'danger',
   IN_PROGRESS: 'warning',
   RESOLVED: 'ok',
-  CLOSED: 'ok',
 }
 
 const severityRailClass: Record<DeviationSeverity, string> = {
@@ -71,10 +69,6 @@ const severityRailClass: Record<DeviationSeverity, string> = {
   MEDIUM: 'deviation-card--medium',
   HIGH: 'deviation-card--high',
   CRITICAL: 'deviation-card--critical',
-}
-
-function normalizedStatus(status: DeviationStatus): DeviationStatus {
-  return status === 'RESOLVED' ? 'CLOSED' : status
 }
 
 const relativeTime = computed(() => toRelativeTime(props.deviation.reportedAt))
@@ -139,22 +133,22 @@ function toRelativeTime(value: string): string {
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
-              :class="normalizedStatus(deviation.status) === 'OPEN' ? 'menu-item--active' : ''"
+              :class="deviation.status === 'OPEN' ? 'menu-item--active' : ''"
               @click="emits('update-status', { id: deviation.id, status: 'OPEN' })"
             >
               <CircleDot :size="16" class="menu-icon--red" />
               Åpen
             </DropdownMenuItem>
             <DropdownMenuItem
-              :class="normalizedStatus(deviation.status) === 'IN_PROGRESS' ? 'menu-item--active' : ''"
+              :class="deviation.status === 'IN_PROGRESS' ? 'menu-item--active' : ''"
               @click="emits('update-status', { id: deviation.id, status: 'IN_PROGRESS' })"
             >
               <Clock :size="16" class="menu-icon--amber" />
               Under behandling
             </DropdownMenuItem>
             <DropdownMenuItem
-              :class="normalizedStatus(deviation.status) === 'CLOSED' ? 'menu-item--active' : ''"
-              @click="emits('update-status', { id: deviation.id, status: 'CLOSED' })"
+              :class="deviation.status === 'RESOLVED' ? 'menu-item--active' : ''"
+              @click="emits('update-status', { id: deviation.id, status: 'RESOLVED' })"
             >
               <CheckCircle2 :size="16" class="menu-icon--green" />
               Løst

--- a/frontend/src/types/deviation.ts
+++ b/frontend/src/types/deviation.ts
@@ -1,6 +1,6 @@
 export type DeviationModule = 'IK_MAT' | 'IK_ALKOHOL'
 export type DeviationSeverity = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL'
-export type DeviationStatus = 'OPEN' | 'IN_PROGRESS' | 'RESOLVED' | 'CLOSED'
+export type DeviationStatus = 'OPEN' | 'IN_PROGRESS' | 'RESOLVED'
 
 export interface Deviation {
   id: number
@@ -17,7 +17,6 @@ export interface Deviation {
   assignedToUserName: string | null
   reportedAt: string
   resolvedAt: string | null
-  closedAt: string | null
   createdAt: string
   updatedAt: string
 }

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onActivated, onMounted } from 'vue'
 import KpiCard from '@/components/dashboard/KpiCard.vue'
 import LatestDeviationCard from '@/components/dashboard/LatestDeviationCard.vue'
 import TemperatureLogCard from '@/components/dashboard/TemperatureLogCard.vue'
@@ -14,6 +14,19 @@ import type { DeviationSeverity } from '@/types/deviation'
 
 const deviationsQuery = useDeviationsQuery()
 const checklistsQuery = useChecklistsQuery()
+
+function refreshDashboardData() {
+  checklistsQuery.refetch()
+  deviationsQuery.refetch()
+}
+
+onMounted(() => {
+  refreshDashboardData()
+})
+
+onActivated(() => {
+  refreshDashboardData()
+})
 
 const kpis = computed<Array<{
   title: string

--- a/frontend/src/views/DeviationDetailView.vue
+++ b/frontend/src/views/DeviationDetailView.vue
@@ -79,7 +79,6 @@ const statusLabel: Record<DeviationStatus, string> = {
   OPEN: 'Åpen',
   IN_PROGRESS: 'Under behandling',
   RESOLVED: 'Løst',
-  CLOSED: 'Løst',
 }
 
 const severityLabel: Record<DeviationSeverity, string> = {
@@ -87,10 +86,6 @@ const severityLabel: Record<DeviationSeverity, string> = {
   MEDIUM: 'Middels',
   HIGH: 'Høy',
   CRITICAL: 'Kritisk',
-}
-
-function normalizedStatus(status: DeviationStatus): DeviationStatus {
-  return status === 'RESOLVED' ? 'CLOSED' : status
 }
 
 function formatDate(value: string | null): string {
@@ -242,11 +237,6 @@ function handleMutationError(error: unknown, fallbackMessage: string) {
                   <span class="date-label">Løst</span>
                   <span class="date-value">{{ formatDate(deviation.resolvedAt) }}</span>
                 </div>
-                <div v-if="deviation.closedAt" class="date-row">
-                  <CheckCircle2 :size="15" class="date-icon date-icon--green" />
-                  <span class="date-label">Lukket</span>
-                  <span class="date-value">{{ formatDate(deviation.closedAt) }}</span>
-                </div>
               </div>
             </div>
 
@@ -257,7 +247,7 @@ function handleMutationError(error: unknown, fallbackMessage: string) {
                 <button
                   type="button"
                   class="status-btn status-btn--open"
-                  :class="{ 'status-btn--active': normalizedStatus(deviation.status) === 'OPEN' }"
+                  :class="{ 'status-btn--active': deviation.status === 'OPEN' }"
                   @click="onStatusClick('OPEN')"
                 >
                   <CircleDot :size="16" />
@@ -266,7 +256,7 @@ function handleMutationError(error: unknown, fallbackMessage: string) {
                 <button
                   type="button"
                   class="status-btn status-btn--in-progress"
-                  :class="{ 'status-btn--active': normalizedStatus(deviation.status) === 'IN_PROGRESS' }"
+                  :class="{ 'status-btn--active': deviation.status === 'IN_PROGRESS' }"
                   @click="onStatusClick('IN_PROGRESS')"
                 >
                   <Clock :size="16" />
@@ -275,8 +265,8 @@ function handleMutationError(error: unknown, fallbackMessage: string) {
                 <button
                   type="button"
                   class="status-btn status-btn--resolved"
-                  :class="{ 'status-btn--active': normalizedStatus(deviation.status) === 'CLOSED' }"
-                  @click="onStatusClick('CLOSED')"
+                  :class="{ 'status-btn--active': deviation.status === 'RESOLVED' }"
+                  @click="onStatusClick('RESOLVED')"
                 >
                   <CheckCircle2 :size="16" />
                   Løst

--- a/frontend/src/views/DeviationsView.vue
+++ b/frontend/src/views/DeviationsView.vue
@@ -99,11 +99,13 @@ const moduleCards = computed(() => [
     key: 'IK_MAT',
     label: 'IK-Mat',
     count: countByModule(deviations.value, 'IK_MAT'),
+    className: 'status-card--neutral',
   },
   {
     key: 'IK_ALKOHOL',
     label: 'IK-Alkohol',
     count: countByModule(deviations.value, 'IK_ALKOHOL'),
+    className: 'status-card--neutral',
   },
 ])
 
@@ -175,16 +177,16 @@ function countSolved(items: Deviation[]): number {
   return items.filter((item) => isSolved(getEffectiveStatus(item))).length
 }
 
+function countByModule(items: Deviation[], module: DeviationModule): number {
+  return items.filter((item) => item.module === module).length
+}
+
 function getEffectiveStatus(item: Deviation): DeviationStatus {
   return statusOverrides.value[item.id] ?? item.status
 }
 
 function isSolved(status: DeviationStatus): boolean {
-  return status === 'RESOLVED' || status === 'CLOSED'
-}
-
-function countByModule(items: Deviation[], module: DeviationModule): number {
-  return items.filter((item) => item.module === module).length
+  return status === 'RESOLVED'
 }
 
 function handleOpenDetails(deviation: Deviation) {
@@ -239,7 +241,7 @@ async function handleDeleteAllSolved() {
 }
 
 async function handleStatusUpdate(payload: { id: number; status: DeviationStatus }) {
-  const nextStatus = payload.status === 'RESOLVED' ? 'CLOSED' : payload.status
+  const nextStatus = payload.status
   const previous = deviations.value.find((item) => item.id === payload.id)
   const previousStatus = previous ? getEffectiveStatus(previous) : null
   const shouldDelayMove = previousStatus ? isSolved(nextStatus) && !isSolved(previousStatus) : false
@@ -320,19 +322,15 @@ function handleMutationError(error: unknown, fallbackMessage: string) {
       </section>
 
       <section class="cards-section" aria-label="Statusoversikt">
-        <div class="cards-group">
-          <article v-for="card in moduleCards" :key="card.key" class="status-card">
-            <span>{{ card.label }}</span>
-            <strong>{{ card.count }}</strong>
-          </article>
-        </div>
+        <article v-for="card in moduleCards" :key="card.key" :class="['status-card', card.className]">
+          <span>{{ card.label }}</span>
+          <strong>{{ card.count }}</strong>
+        </article>
 
-        <div class="cards-group">
-          <article v-for="card in statusCards" :key="card.key" :class="['status-card', card.className]">
-            <span>{{ card.label }}</span>
-            <strong>{{ card.count }}</strong>
-          </article>
-        </div>
+        <article v-for="card in statusCards" :key="card.key" :class="['status-card', card.className]">
+          <span>{{ card.label }}</span>
+          <strong>{{ card.count }}</strong>
+        </article>
       </section>
 
       <section class="filters-row">
@@ -490,28 +488,16 @@ h1 {
 }
 
 .cards-section {
-  display: flex;
-  gap: 20px;
-}
-
-.cards-group {
   display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 10px;
-  flex: 1;
-}
-
-.cards-group:first-child {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.cards-group:last-child {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .status-card {
-  border: 1px solid var(--border);
+  border: 2px solid #d1d5db;
   border-radius: var(--radius-md);
   padding: 12px;
+  min-height: 6.25rem;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -522,22 +508,31 @@ h1 {
 .status-card strong { font-size: 2rem; letter-spacing: -0.02em; }
 
 .status-card--open {
-  background: #fdf5f5;
-  border-color: #f0d0d0;
+  background: #f5e8ea;
+  border-color: #e0aeb5;
 }
 .status-card--open strong { color: #a62929; }
 
 .status-card--in-progress {
-  background: #fdf9f0;
-  border-color: #f0ddb0;
+  background: #f1e7d6;
+  border-color: #e0bf81;
 }
 .status-card--in-progress strong { color: #946013; }
 
 .status-card--resolved {
-  background: #f3faf2;
-  border-color: #c8e4c2;
+  background: #e4eddc;
+  border-color: #b7d18e;
 }
 .status-card--resolved strong { color: #3c8f2c; }
+
+.status-card--neutral {
+  background: #ffffff;
+  border-color: #d1d5db;
+}
+
+.status-card--neutral strong {
+  color: #111827;
+}
 
 .filters-row {
   display: flex;
@@ -687,13 +682,12 @@ h1 {
 }
 
 @media (max-width: 1100px) {
-  .cards-section { flex-direction: column; gap: 10px; }
+  .cards-section { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (max-width: 760px) {
   .header-row { flex-direction: column; }
-  .cards-group:first-child { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .cards-group:last-child { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .cards-section { grid-template-columns: 1fr; }
   .filters-row { align-items: stretch; }
   .filters-left { flex-direction: column; }
   .filters-right { width: 100%; justify-content: flex-end; }


### PR DESCRIPTION
This pull request removes the "CLOSED" status from deviations across both backend and frontend, simplifying the deviation status model to only "OPEN", "IN_PROGRESS", and "RESOLVED". All related backend data structures, database seeds, and frontend logic, types, and UI elements have been updated to reflect this change. Additionally, there are minor improvements to dashboard data refreshing and KPI calculation.

**Backend changes:**

* Removed the `CLOSED` status from the `DeviationStatus` enum and all related logic, including database models (`Deviation`), DTOs (`DeviationResponse`), and service logic. The `closedAt` property and handling have been eliminated. [[1]](diffhunk://#diff-761fe8c2739131439cff702d2b54e84c1b5ceb2b53e94fc7daadc597867776ecL10) [[2]](diffhunk://#diff-3f6378a158071c759f1afc7a87981b481322d9b54945da899a58b29c4b8bb936L64-L66) [[3]](diffhunk://#diff-93cc18c00bbeababb6e1d865224c05ce06ce18b79558ee0e35b55c21adbb6f02L67) [[4]](diffhunk://#diff-125ac9037bc60593d0effdeb1bf836a261eca7a4dd91d4c6e572fe8f87e6d920L110-L123) [[5]](diffhunk://#diff-125ac9037bc60593d0effdeb1bf836a261eca7a4dd91d4c6e572fe8f87e6d920L178)
* Updated the database seed data to remove references to `closed_at` and the `CLOSED` status, ensuring all seed deviations now use the updated status model. [[1]](diffhunk://#diff-8ae85b474d2aa0a33eebb846ad808598012b5deb0a4b16e5350ae6e7c31cfeb3L12-R12) [[2]](diffhunk://#diff-8ae85b474d2aa0a33eebb846ad808598012b5deb0a4b16e5350ae6e7c31cfeb3L27) [[3]](diffhunk://#diff-8ae85b474d2aa0a33eebb846ad808598012b5deb0a4b16e5350ae6e7c31cfeb3L41) [[4]](diffhunk://#diff-8ae85b474d2aa0a33eebb846ad808598012b5deb0a4b16e5350ae6e7c31cfeb3L55) [[5]](diffhunk://#diff-8ae85b474d2aa0a33eebb846ad808598012b5deb0a4b16e5350ae6e7c31cfeb3L69-R65) [[6]](diffhunk://#diff-8ae85b474d2aa0a33eebb846ad808598012b5deb0a4b16e5350ae6e7c31cfeb3L79-R78)

**Frontend changes:**

* Updated the `DeviationStatus` type and all related UI components to remove the `CLOSED` status and the `closedAt` property, adjusting status labels, status button logic, and dropdowns to use only the remaining statuses. [[1]](diffhunk://#diff-d6900706c34bc2f32fdcacc699bf2617bf91dc4467250f522429c718055deb3cL3-R3) [[2]](diffhunk://#diff-d6900706c34bc2f32fdcacc699bf2617bf91dc4467250f522429c718055deb3cL20) [[3]](diffhunk://#diff-7168e55184dc76cc083a8fd701014a6be41fd31eb27c44f2a2e8c561d3e4317cL48) [[4]](diffhunk://#diff-7168e55184dc76cc083a8fd701014a6be41fd31eb27c44f2a2e8c561d3e4317cL68-L74) [[5]](diffhunk://#diff-7168e55184dc76cc083a8fd701014a6be41fd31eb27c44f2a2e8c561d3e4317cL131-L134) [[6]](diffhunk://#diff-7168e55184dc76cc083a8fd701014a6be41fd31eb27c44f2a2e8c561d3e4317cL149-R140) [[7]](diffhunk://#diff-96abcc711b5ccfbbf134adb50077f0040e82e49ae5769774594be4b0f7cf056dL45) [[8]](diffhunk://#diff-96abcc711b5ccfbbf134adb50077f0040e82e49ae5769774594be4b0f7cf056dL66) [[9]](diffhunk://#diff-96abcc711b5ccfbbf134adb50077f0040e82e49ae5769774594be4b0f7cf056dL76-L79) [[10]](diffhunk://#diff-96abcc711b5ccfbbf134adb50077f0040e82e49ae5769774594be4b0f7cf056dL142-R151) [[11]](diffhunk://#diff-dba805fc99e4ceec9f667a75b0a16b621897d7f7baa6f459082a12b7f90bc4b5L82) [[12]](diffhunk://#diff-dba805fc99e4ceec9f667a75b0a16b621897d7f7baa6f459082a12b7f90bc4b5L92-L95) [[13]](diffhunk://#diff-dba805fc99e4ceec9f667a75b0a16b621897d7f7baa6f459082a12b7f90bc4b5L245-L249) [[14]](diffhunk://#diff-dba805fc99e4ceec9f667a75b0a16b621897d7f7baa6f459082a12b7f90bc4b5L260-R250) [[15]](diffhunk://#diff-dba805fc99e4ceec9f667a75b0a16b621897d7f7baa6f459082a12b7f90bc4b5L269-R259) [[16]](diffhunk://#diff-dba805fc99e4ceec9f667a75b0a16b621897d7f7baa6f459082a12b7f90bc4b5L278-R269)
* Removed all UI elements and logic related to displaying or updating the "closed" status and date, ensuring a consistent user experience. [[1]](diffhunk://#diff-7168e55184dc76cc083a8fd701014a6be41fd31eb27c44f2a2e8c561d3e4317cL131-L134) [[2]](diffhunk://#diff-dba805fc99e4ceec9f667a75b0a16b621897d7f7baa6f459082a12b7f90bc4b5L245-L249)

**Other improvements:**

* Improved KPI progress calculation in `KpiCard.vue` by using a computed property and clamping the percentage between 0 and 100. [[1]](diffhunk://#diff-904ec9df8d340f8ecc4a7f292c6ee79f38bfa8457000cab56be943ea6ec1405cR2-R3) [[2]](diffhunk://#diff-904ec9df8d340f8ecc4a7f292c6ee79f38bfa8457000cab56be943ea6ec1405cL20-R29)
* Added automatic dashboard data refresh on mount and activation in `DashboardView.vue` for a more up-to-date user experience. [[1]](diffhunk://#diff-703be6973b91920326c19884a54e626f64fd4a9508b6b38b4e73e39effb397faL2-R2) [[2]](diffhunk://#diff-703be6973b91920326c19884a54e626f64fd4a9508b6b38b4e73e39effb397faR18-R30)
* Minor UI enhancement: added a neutral class to module status cards in `DeviationsView.vue`.