### PR TITLE
training page and backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 COPY . .
-RUN mvn package -DskipTests -B
+RUN mvn package -B
 
 # Stage 2: Run
 FROM eclipse-temurin:21-jre-alpine

--- a/backend/src/main/kotlin/com/iksystem/ik-common/training/controller/TrainingController.kt
+++ b/backend/src/main/kotlin/com/iksystem/ik-common/training/controller/TrainingController.kt
@@ -1,0 +1,95 @@
+package com.iksystem.`ik-common`.training.controller
+
+import com.iksystem.`ik-common`.security.AuthenticatedUser
+import com.iksystem.`ik-common`.training.dto.CreateTrainingLogRequest
+import com.iksystem.`ik-common`.training.dto.TrainingLogResponse
+import com.iksystem.`ik-common`.training.dto.UpdateTrainingLogRequest
+import com.iksystem.`ik-common`.training.service.TrainingService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Training Logs", description = "Staff training record management")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/api/v1/training-logs")
+class TrainingController(
+    private val trainingService: TrainingService,
+) {
+
+    @Operation(summary = "List training logs", description = "Returns all training logs for the active organization.")
+    @ApiResponse(responseCode = "200", description = "Training log list returned")
+    @GetMapping
+    fun list(@AuthenticationPrincipal auth: AuthenticatedUser): ResponseEntity<List<TrainingLogResponse>> =
+        ResponseEntity.ok(trainingService.list(auth))
+
+    @Operation(summary = "Get training log", description = "Returns one training log by ID in the active organization.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "Training log returned"),
+        ApiResponse(responseCode = "404", description = "Training log not found"),
+    )
+    @GetMapping("/{id}")
+    fun getById(
+        @PathVariable id: Long,
+        @AuthenticationPrincipal auth: AuthenticatedUser,
+    ): ResponseEntity<TrainingLogResponse> =
+        ResponseEntity.ok(trainingService.getById(id, auth))
+
+    @Operation(summary = "Create training log", description = "Creates a new training log entry in the active organization.")
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "Training log created"),
+        ApiResponse(responseCode = "400", description = "Validation error"),
+    )
+    @PostMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    fun create(
+        @Valid @RequestBody request: CreateTrainingLogRequest,
+        @AuthenticationPrincipal auth: AuthenticatedUser,
+    ): ResponseEntity<TrainingLogResponse> =
+        ResponseEntity.status(HttpStatus.CREATED).body(trainingService.create(request, auth))
+
+    @Operation(summary = "Update training log", description = "Updates a training log entry.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "Training log updated"),
+        ApiResponse(responseCode = "400", description = "No update fields or invalid payload"),
+        ApiResponse(responseCode = "404", description = "Training log not found"),
+    )
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    fun update(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdateTrainingLogRequest,
+        @AuthenticationPrincipal auth: AuthenticatedUser,
+    ): ResponseEntity<TrainingLogResponse> =
+        ResponseEntity.ok(trainingService.update(id, request, auth))
+
+    @Operation(summary = "Delete training log", description = "Deletes a training log entry.")
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "Training log deleted"),
+        ApiResponse(responseCode = "404", description = "Training log not found"),
+    )
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    fun delete(
+        @PathVariable id: Long,
+        @AuthenticationPrincipal auth: AuthenticatedUser,
+    ): ResponseEntity<Void> {
+        trainingService.delete(id, auth)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/backend/src/main/kotlin/com/iksystem/ik-common/training/dto/TrainingDtos.kt
+++ b/backend/src/main/kotlin/com/iksystem/ik-common/training/dto/TrainingDtos.kt
@@ -1,0 +1,57 @@
+package com.iksystem.`ik-common`.training.dto
+
+import com.iksystem.`ik-common`.training.model.TrainingStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+data class CreateTrainingLogRequest(
+    @field:NotNull(message = "Employee user ID is required")
+    val employeeUserId: Long,
+
+    @field:NotBlank(message = "Title is required")
+    @field:Size(max = 255, message = "Title cannot exceed 255 characters")
+    val title: String,
+
+    @field:Size(max = 5000, message = "Description cannot exceed 5000 characters")
+    val description: String? = null,
+
+    val completedAt: String? = null,
+
+    val expiresAt: String? = null,
+
+    @field:NotNull(message = "Status is required")
+    val status: TrainingStatus,
+)
+
+data class UpdateTrainingLogRequest(
+    val employeeUserId: Long? = null,
+
+    @field:Size(max = 255, message = "Title cannot exceed 255 characters")
+    val title: String? = null,
+
+    @field:Size(max = 5000, message = "Description cannot exceed 5000 characters")
+    val description: String? = null,
+
+    val completedAt: String? = null,
+
+    val expiresAt: String? = null,
+
+    val status: TrainingStatus? = null,
+)
+
+data class TrainingLogResponse(
+    val id: Long,
+    val organizationId: Long,
+    val employeeUserId: Long,
+    val employeeUserName: String,
+    val loggedByUserId: Long,
+    val loggedByUserName: String,
+    val title: String,
+    val description: String?,
+    val completedAt: String?,
+    val expiresAt: String?,
+    val status: TrainingStatus,
+    val createdAt: String,
+    val updatedAt: String,
+)

--- a/backend/src/main/kotlin/com/iksystem/ik-common/training/model/TrainingLog.kt
+++ b/backend/src/main/kotlin/com/iksystem/ik-common/training/model/TrainingLog.kt
@@ -1,0 +1,55 @@
+package com.iksystem.`ik-common`.training.model
+
+import com.iksystem.`ik-common`.user.model.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "training_logs")
+data class TrainingLog(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(name = "organization_id", nullable = false)
+    val organizationId: Long,
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "employee_user_id", nullable = false)
+    val employeeUser: User,
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "logged_by_user_id", nullable = false)
+    val loggedByUser: User,
+
+    @Column(nullable = false)
+    val title: String,
+
+    @Column(columnDefinition = "TEXT")
+    val description: String? = null,
+
+    @Column(name = "completed_at")
+    val completedAt: Instant? = null,
+
+    @Column(name = "expires_at")
+    val expiresAt: Instant? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val status: TrainingStatus = TrainingStatus.NOT_COMPLETED,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: Instant = Instant.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: Instant = Instant.now(),
+)

--- a/backend/src/main/kotlin/com/iksystem/ik-common/training/model/TrainingStatus.kt
+++ b/backend/src/main/kotlin/com/iksystem/ik-common/training/model/TrainingStatus.kt
@@ -1,0 +1,8 @@
+package com.iksystem.`ik-common`.training.model
+
+enum class TrainingStatus {
+    COMPLETED,
+    EXPIRES_SOON,
+    EXPIRED,
+    NOT_COMPLETED,
+}

--- a/backend/src/main/kotlin/com/iksystem/ik-common/training/repository/TrainingRepository.kt
+++ b/backend/src/main/kotlin/com/iksystem/ik-common/training/repository/TrainingRepository.kt
@@ -1,0 +1,13 @@
+package com.iksystem.`ik-common`.training.repository
+
+import com.iksystem.`ik-common`.training.model.TrainingLog
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TrainingRepository : JpaRepository<TrainingLog, Long> {
+
+    fun findAllByOrganizationIdOrderByCreatedAtDesc(organizationId: Long): List<TrainingLog>
+
+    fun findByIdAndOrganizationId(id: Long, organizationId: Long): TrainingLog?
+}

--- a/backend/src/main/kotlin/com/iksystem/ik-common/training/service/TrainingService.kt
+++ b/backend/src/main/kotlin/com/iksystem/ik-common/training/service/TrainingService.kt
@@ -1,0 +1,138 @@
+package com.iksystem.`ik-common`.training.service
+
+import com.ik.ikcommon.exception.BadRequestException
+import com.ik.ikcommon.exception.NotFoundException
+import com.iksystem.`ik-common`.membership.repository.MembershipRepository
+import com.iksystem.`ik-common`.security.AuthenticatedUser
+import com.iksystem.`ik-common`.training.dto.CreateTrainingLogRequest
+import com.iksystem.`ik-common`.training.dto.TrainingLogResponse
+import com.iksystem.`ik-common`.training.dto.UpdateTrainingLogRequest
+import com.iksystem.`ik-common`.training.model.TrainingLog
+import com.iksystem.`ik-common`.training.repository.TrainingRepository
+import com.iksystem.`ik-common`.user.model.User
+import com.iksystem.`ik-common`.user.repository.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class TrainingService(
+    private val trainingRepository: TrainingRepository,
+    private val userRepository: UserRepository,
+    private val membershipRepository: MembershipRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun list(auth: AuthenticatedUser): List<TrainingLogResponse> {
+        val orgId = auth.requireOrganizationId()
+        return trainingRepository.findAllByOrganizationIdOrderByCreatedAtDesc(orgId)
+            .map { it.toResponse() }
+    }
+
+    @Transactional(readOnly = true)
+    fun getById(id: Long, auth: AuthenticatedUser): TrainingLogResponse {
+        val orgId = auth.requireOrganizationId()
+        return requireTrainingLog(id, orgId).toResponse()
+    }
+
+    @Transactional
+    fun create(request: CreateTrainingLogRequest, auth: AuthenticatedUser): TrainingLogResponse {
+        val orgId = auth.requireOrganizationId()
+        val employee = requireMember(request.employeeUserId, orgId)
+        val loggedBy = requireUser(auth.userId)
+
+        val trainingLog = trainingRepository.save(
+            TrainingLog(
+                organizationId = orgId,
+                employeeUser = employee,
+                loggedByUser = loggedBy,
+                title = request.title.trim(),
+                description = request.description?.trim()?.takeIf { it.isNotEmpty() },
+                completedAt = request.completedAt?.let { Instant.parse(it) },
+                expiresAt = request.expiresAt?.let { Instant.parse(it) },
+                status = request.status,
+            )
+        )
+
+        return trainingLog.toResponse()
+    }
+
+    @Transactional
+    fun update(id: Long, request: UpdateTrainingLogRequest, auth: AuthenticatedUser): TrainingLogResponse {
+        val orgId = auth.requireOrganizationId()
+        val existing = requireTrainingLog(id, orgId)
+
+        if (
+            request.employeeUserId == null &&
+            request.title == null &&
+            request.description == null &&
+            request.completedAt == null &&
+            request.expiresAt == null &&
+            request.status == null
+        ) {
+            throw BadRequestException("No fields provided to update")
+        }
+
+        val employee = if (request.employeeUserId != null) {
+            requireMember(request.employeeUserId, orgId)
+        } else {
+            existing.employeeUser
+        }
+
+        val updated = trainingRepository.save(
+            existing.copy(
+                employeeUser = employee,
+                title = request.title?.trim()?.takeIf { it.isNotEmpty() } ?: existing.title,
+                description = request.description?.trim()?.takeIf { it.isNotEmpty() } ?: existing.description,
+                completedAt = request.completedAt?.let { Instant.parse(it) } ?: existing.completedAt,
+                expiresAt = request.expiresAt?.let { Instant.parse(it) } ?: existing.expiresAt,
+                status = request.status ?: existing.status,
+                updatedAt = Instant.now(),
+            )
+        )
+
+        return updated.toResponse()
+    }
+
+    @Transactional
+    fun delete(id: Long, auth: AuthenticatedUser) {
+        val orgId = auth.requireOrganizationId()
+        val trainingLog = requireTrainingLog(id, orgId)
+        trainingRepository.delete(trainingLog)
+    }
+
+    private fun requireTrainingLog(id: Long, organizationId: Long): TrainingLog {
+        return trainingRepository.findByIdAndOrganizationId(id, organizationId)
+            ?: throw NotFoundException("Training log not found")
+    }
+
+    private fun requireUser(userId: Long): User {
+        return userRepository.findById(userId)
+            .orElseThrow { NotFoundException("User not found") }
+    }
+
+    private fun requireMember(userId: Long, organizationId: Long): User {
+        val user = requireUser(userId)
+        val isMember = membershipRepository.existsByUserIdAndOrganizationId(user.id, organizationId)
+        if (!isMember) {
+            throw BadRequestException("Employee is not a member of this organization")
+        }
+        return user
+    }
+}
+
+private fun TrainingLog.toResponse(): TrainingLogResponse = TrainingLogResponse(
+    id = id,
+    organizationId = organizationId,
+    employeeUserId = employeeUser.id,
+    employeeUserName = employeeUser.fullName,
+    loggedByUserId = loggedByUser.id,
+    loggedByUserName = loggedByUser.fullName,
+    title = title,
+    description = description,
+    completedAt = completedAt?.toString(),
+    expiresAt = expiresAt?.toString(),
+    status = status,
+    createdAt = createdAt.toString(),
+    updatedAt = updatedAt.toString(),
+)

--- a/backend/src/main/resources/db/migration/V10__seed_training_logs_data.sql
+++ b/backend/src/main/resources/db/migration/V10__seed_training_logs_data.sql
@@ -1,0 +1,61 @@
+INSERT INTO training_logs (
+    organization_id,
+    employee_user_id,
+    logged_by_user_id,
+    title,
+    description,
+    completed_at,
+    expires_at,
+    status
+)
+VALUES
+    (
+        (SELECT id FROM organizations WHERE name = 'IK System'),
+        (SELECT id FROM users WHERE email = 'employee@iksystem.local'),
+        (SELECT id FROM users WHERE email = 'admin@iksystem.local'),
+        'Brannvernkurs',
+        'Årlig brannvernopplæring for alle ansatte.',
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 3 MONTH),
+        DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 9 MONTH),
+        'COMPLETED'
+    ),
+    (
+        (SELECT id FROM organizations WHERE name = 'IK System'),
+        (SELECT id FROM users WHERE email = 'manager@iksystem.local'),
+        (SELECT id FROM users WHERE email = 'admin@iksystem.local'),
+        'HMS-kurs',
+        'Grunnleggende HMS-opplæring.',
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 11 MONTH),
+        DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 20 DAY),
+        'EXPIRES_SOON'
+    ),
+    (
+        (SELECT id FROM organizations WHERE name = 'IK System'),
+        (SELECT id FROM users WHERE email = 'employee@iksystem.local'),
+        (SELECT id FROM users WHERE email = 'manager@iksystem.local'),
+        'Allergenopplæring',
+        'Opplæring i allergenhåndtering for kjøkkenpersonell.',
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 14 MONTH),
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 2 MONTH),
+        'EXPIRED'
+    ),
+    (
+        (SELECT id FROM organizations WHERE name = 'IK System'),
+        (SELECT id FROM users WHERE email = 'manager@iksystem.local'),
+        (SELECT id FROM users WHERE email = 'admin@iksystem.local'),
+        'Ansvarlig vertskap',
+        'Kurs i ansvarlig alkoholservering.',
+        NULL,
+        NULL,
+        'NOT_COMPLETED'
+    ),
+    (
+        (SELECT id FROM organizations WHERE name = 'Demo Organization'),
+        (SELECT id FROM users WHERE email = 'employee@iksystem.local'),
+        (SELECT id FROM users WHERE email = 'employee@iksystem.local'),
+        'Førstehjelp',
+        'Grunnkurs i førstehjelp.',
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 1 MONTH),
+        DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 11 MONTH),
+        'COMPLETED'
+    );

--- a/backend/src/main/resources/db/migration/V9__add_training_logs_schema.sql
+++ b/backend/src/main/resources/db/migration/V9__add_training_logs_schema.sql
@@ -1,0 +1,23 @@
+CREATE TABLE training_logs (
+    id              BIGINT       NOT NULL AUTO_INCREMENT,
+    organization_id BIGINT       NOT NULL,
+    employee_user_id BIGINT      NOT NULL,
+    logged_by_user_id BIGINT     NOT NULL,
+    title           VARCHAR(255) NOT NULL,
+    description     TEXT,
+    completed_at    TIMESTAMP    NULL,
+    expires_at      TIMESTAMP    NULL,
+    status          VARCHAR(20)  NOT NULL DEFAULT 'NOT_COMPLETED',
+    created_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+    CONSTRAINT fk_training_logs_organization  FOREIGN KEY (organization_id)   REFERENCES organizations(id) ON DELETE CASCADE,
+    CONSTRAINT fk_training_logs_employee      FOREIGN KEY (employee_user_id)  REFERENCES users(id)         ON DELETE RESTRICT,
+    CONSTRAINT fk_training_logs_logged_by     FOREIGN KEY (logged_by_user_id) REFERENCES users(id)         ON DELETE RESTRICT
+);
+
+CREATE INDEX idx_training_logs_organization_id  ON training_logs(organization_id);
+CREATE INDEX idx_training_logs_employee_user_id ON training_logs(employee_user_id);
+CREATE INDEX idx_training_logs_status           ON training_logs(status);
+CREATE INDEX idx_training_logs_expires_at       ON training_logs(expires_at);

--- a/backend/src/test/kotlin/com/iksystem/ik-common/training/service/TrainingServiceTest.kt
+++ b/backend/src/test/kotlin/com/iksystem/ik-common/training/service/TrainingServiceTest.kt
@@ -1,0 +1,208 @@
+package com.iksystem.`ik-common`.training.service
+
+import com.ik.ikcommon.exception.BadRequestException
+import com.ik.ikcommon.exception.NotFoundException
+import com.iksystem.`ik-common`.membership.repository.MembershipRepository
+import com.iksystem.`ik-common`.security.AuthenticatedUser
+import com.iksystem.`ik-common`.training.dto.CreateTrainingLogRequest
+import com.iksystem.`ik-common`.training.dto.UpdateTrainingLogRequest
+import com.iksystem.`ik-common`.training.model.TrainingLog
+import com.iksystem.`ik-common`.training.model.TrainingStatus
+import com.iksystem.`ik-common`.training.repository.TrainingRepository
+import com.iksystem.`ik-common`.user.model.User
+import com.iksystem.`ik-common`.user.repository.UserRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.*
+import java.time.Instant
+import java.util.*
+
+class TrainingServiceTest : FunSpec({
+
+    val trainingRepository = mockk<TrainingRepository>()
+    val userRepository = mockk<UserRepository>()
+    val membershipRepository = mockk<MembershipRepository>()
+
+    val service = TrainingService(
+        trainingRepository = trainingRepository,
+        userRepository = userRepository,
+        membershipRepository = membershipRepository,
+    )
+
+    val admin = User(id = 1L, email = "admin@test.com", password = "hashed", fullName = "Admin User", phoneNumber = "+47123")
+    val employee = User(id = 2L, email = "employee@test.com", password = "hashed", fullName = "Employee User", phoneNumber = "+47124")
+    val orgId = 10L
+    val auth = AuthenticatedUser(userId = 1L, organizationId = orgId, role = "ADMIN")
+
+    val trainingLog = TrainingLog(
+        id = 1L,
+        organizationId = orgId,
+        employeeUser = employee,
+        loggedByUser = admin,
+        title = "Brannvernkurs",
+        description = "Årlig brannvernopplæring",
+        completedAt = Instant.parse("2026-01-15T10:00:00Z"),
+        expiresAt = Instant.parse("2027-01-15T10:00:00Z"),
+        status = TrainingStatus.COMPLETED,
+    )
+
+    beforeTest {
+        clearMocks(trainingRepository, userRepository, membershipRepository)
+    }
+
+    test("list returns all training logs for the organization") {
+        val log2 = trainingLog.copy(id = 2L, title = "HMS-kurs")
+        every { trainingRepository.findAllByOrganizationIdOrderByCreatedAtDesc(orgId) } returns listOf(trainingLog, log2)
+
+        val result = service.list(auth)
+
+        result shouldHaveSize 2
+        result[0].title shouldBe "Brannvernkurs"
+        result[1].title shouldBe "HMS-kurs"
+    }
+
+    test("getById returns training log") {
+        every { trainingRepository.findByIdAndOrganizationId(1L, orgId) } returns trainingLog
+
+        val result = service.getById(1L, auth)
+
+        result.id shouldBe 1L
+        result.title shouldBe "Brannvernkurs"
+        result.employeeUserId shouldBe 2L
+        result.employeeUserName shouldBe "Employee User"
+        result.loggedByUserId shouldBe 1L
+        result.loggedByUserName shouldBe "Admin User"
+        result.status shouldBe TrainingStatus.COMPLETED
+    }
+
+    test("getById throws NotFoundException for unknown id") {
+        every { trainingRepository.findByIdAndOrganizationId(99L, orgId) } returns null
+
+        shouldThrow<NotFoundException> {
+            service.getById(99L, auth)
+        }
+    }
+
+    test("create saves training log and sets loggedByUser from auth") {
+        val request = CreateTrainingLogRequest(
+            employeeUserId = 2L,
+            title = "Brannvernkurs",
+            description = "Årlig brannvernopplæring",
+            completedAt = "2026-01-15T10:00:00Z",
+            expiresAt = "2027-01-15T10:00:00Z",
+            status = TrainingStatus.COMPLETED,
+        )
+
+        every { userRepository.findById(2L) } returns Optional.of(employee)
+        every { membershipRepository.existsByUserIdAndOrganizationId(2L, orgId) } returns true
+        every { userRepository.findById(1L) } returns Optional.of(admin)
+        every { trainingRepository.save(any()) } answers { firstArg<TrainingLog>().copy(id = 1L) }
+
+        val result = service.create(request, auth)
+
+        result.title shouldBe "Brannvernkurs"
+        result.employeeUserId shouldBe 2L
+        result.loggedByUserId shouldBe 1L
+        result.status shouldBe TrainingStatus.COMPLETED
+        verify { trainingRepository.save(match { it.loggedByUser == admin && it.employeeUser == employee }) }
+    }
+
+    test("create throws BadRequestException when employee is not a member of the org") {
+        val request = CreateTrainingLogRequest(
+            employeeUserId = 2L,
+            title = "Kurs",
+            status = TrainingStatus.NOT_COMPLETED,
+        )
+
+        every { userRepository.findById(2L) } returns Optional.of(employee)
+        every { membershipRepository.existsByUserIdAndOrganizationId(2L, orgId) } returns false
+
+        shouldThrow<BadRequestException> {
+            service.create(request, auth)
+        }
+    }
+
+    test("create throws NotFoundException for unknown employee") {
+        val request = CreateTrainingLogRequest(
+            employeeUserId = 99L,
+            title = "Kurs",
+            status = TrainingStatus.NOT_COMPLETED,
+        )
+
+        every { userRepository.findById(99L) } returns Optional.empty()
+
+        shouldThrow<NotFoundException> {
+            service.create(request, auth)
+        }
+    }
+
+    test("update modifies training log fields") {
+        val request = UpdateTrainingLogRequest(
+            title = "Updated Title",
+            status = TrainingStatus.EXPIRED,
+        )
+
+        every { trainingRepository.findByIdAndOrganizationId(1L, orgId) } returns trainingLog
+        every { trainingRepository.save(any()) } answers { firstArg() }
+
+        val result = service.update(1L, request, auth)
+
+        result.title shouldBe "Updated Title"
+        result.status shouldBe TrainingStatus.EXPIRED
+        result.employeeUserId shouldBe 2L
+    }
+
+    test("update changes employee when employeeUserId is provided") {
+        val newEmployee = User(id = 3L, email = "new@test.com", password = "hashed", fullName = "New Employee", phoneNumber = "+47125")
+        val request = UpdateTrainingLogRequest(employeeUserId = 3L)
+
+        every { trainingRepository.findByIdAndOrganizationId(1L, orgId) } returns trainingLog
+        every { userRepository.findById(3L) } returns Optional.of(newEmployee)
+        every { membershipRepository.existsByUserIdAndOrganizationId(3L, orgId) } returns true
+        every { trainingRepository.save(any()) } answers { firstArg() }
+
+        val result = service.update(1L, request, auth)
+
+        result.employeeUserId shouldBe 3L
+        result.employeeUserName shouldBe "New Employee"
+    }
+
+    test("update throws BadRequestException when no fields provided") {
+        val request = UpdateTrainingLogRequest()
+
+        every { trainingRepository.findByIdAndOrganizationId(1L, orgId) } returns trainingLog
+
+        shouldThrow<BadRequestException> {
+            service.update(1L, request, auth)
+        }
+    }
+
+    test("update throws NotFoundException for unknown training log") {
+        val request = UpdateTrainingLogRequest(title = "New Title")
+
+        every { trainingRepository.findByIdAndOrganizationId(99L, orgId) } returns null
+
+        shouldThrow<NotFoundException> {
+            service.update(99L, request, auth)
+        }
+    }
+
+    test("delete removes existing training log") {
+        every { trainingRepository.findByIdAndOrganizationId(1L, orgId) } returns trainingLog
+        every { trainingRepository.delete(trainingLog) } just runs
+
+        service.delete(1L, auth)
+
+        verify { trainingRepository.delete(trainingLog) }
+    }
+
+    test("delete throws NotFoundException for unknown training log") {
+        every { trainingRepository.findByIdAndOrganizationId(99L, orgId) } returns null
+
+        shouldThrow<NotFoundException> {
+            service.delete(99L, auth)
+        }
+    }
+})

--- a/frontend/src/components/training/EditTrainingModal.vue
+++ b/frontend/src/components/training/EditTrainingModal.vue
@@ -1,185 +1,202 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
-import { X, Check, Trash2 } from 'lucide-vue-next'
-import type { Training } from '@/stores/training'
-import { useTrainingStore } from '@/stores/training'
+import { ref, watch, computed } from 'vue'
+import axios from 'axios'
+import { toast } from 'vue-sonner'
+import Dialog from '@/components/ui/dialog/Dialog.vue'
+import DialogContent from '@/components/ui/dialog/DialogContent.vue'
+import DialogDescription from '@/components/ui/dialog/DialogDescription.vue'
+import DialogFooter from '@/components/ui/dialog/DialogFooter.vue'
+import DialogHeader from '@/components/ui/dialog/DialogHeader.vue'
+import DialogTitle from '@/components/ui/dialog/DialogTitle.vue'
 import Button from '@/components/ui/button/Button.vue'
+import Input from '@/components/ui/input/Input.vue'
+import Textarea from '@/components/ui/textarea/Textarea.vue'
+import {
+  useUpdateTrainingLogMutation,
+  useOrganizationMembersQuery,
+} from '@/composables/useTrainingLogs'
+import type { TrainingLog, TrainingStatus } from '@/types/training'
 
 const props = defineProps<{
-  modelValue: boolean
-  training: Training | null
-  employeeId: number | undefined
+  open: boolean
+  training: TrainingLog | null
 }>()
-const emit = defineEmits<{ 'update:modelValue': [value: boolean] }>()
+const emits = defineEmits<{ (e: 'update:open', value: boolean): void }>()
 
-const store = useTrainingStore()
-const form  = ref<Omit<Training, 'id'>>({ type: '', completed: null, expires: null, status: 'Gyldig' })
-const deleteConfirm = ref(false)
+const updateMutation = useUpdateTrainingLogMutation()
+const canManage = computed(() => true)
+const membersQuery = useOrganizationMembersQuery(canManage)
+const members = computed(() => membersQuery.data.value ?? [])
 
-watch(() => props.training, (t) => {
-  if (t) {
-    form.value = { type: t.type, completed: t.completed, expires: t.expires, status: t.status }
-    deleteConfirm.value = false
-  }
-}, { immediate: true })
+const employeeUserId = ref<string>('')
+const title = ref('')
+const description = ref('')
+const completedAt = ref('')
+const expiresAt = ref('')
+const status = ref<TrainingStatus>('COMPLETED')
+const errorMessage = ref('')
 
-function close(): void { emit('update:modelValue', false) }
+const statusOptions: Array<{ value: TrainingStatus; label: string }> = [
+  { value: 'COMPLETED', label: 'Fullført' },
+  { value: 'EXPIRES_SOON', label: 'Utløper snart' },
+  { value: 'EXPIRED', label: 'Utgått' },
+  { value: 'NOT_COMPLETED', label: 'Ikke fullført' },
+]
 
-function save(): void {
-  if (!props.training || !props.employeeId) return
-  store.updateTraining(props.employeeId, props.training.id, form.value)
-  close()
+function isoToDateInput(iso: string | null): string {
+  if (!iso) return ''
+  return iso.slice(0, 10)
 }
 
-function remove(): void {
-  if (!props.training || !props.employeeId) return
-  store.deleteTraining(props.employeeId, props.training.id)
-  close()
+watch(
+  () => [props.open, props.training],
+  ([isOpen]) => {
+    if (!isOpen) return
+    if (props.training) {
+      employeeUserId.value = String(props.training.employeeUserId)
+      title.value = props.training.title
+      description.value = props.training.description ?? ''
+      completedAt.value = isoToDateInput(props.training.completedAt)
+      expiresAt.value = isoToDateInput(props.training.expiresAt)
+      status.value = props.training.status
+    }
+    errorMessage.value = ''
+  },
+)
+
+function closeDialog() {
+  emits('update:open', false)
+}
+
+function toIso(dateStr: string): string | undefined {
+  if (!dateStr) return undefined
+  return new Date(dateStr + 'T00:00:00Z').toISOString()
+}
+
+async function handleSubmit() {
+  if (!props.training) return
+  const trimmedTitle = title.value.trim()
+  if (!trimmedTitle) {
+    errorMessage.value = 'Opplæringstype er påkrevd.'
+    return
+  }
+  errorMessage.value = ''
+
+  try {
+    await updateMutation.mutateAsync({
+      id: props.training.id,
+      payload: {
+        employeeUserId: Number(employeeUserId.value) || undefined,
+        title: trimmedTitle || undefined,
+        description: description.value.trim() || undefined,
+        completedAt: toIso(completedAt.value),
+        expiresAt: toIso(expiresAt.value),
+        status: status.value,
+      },
+    })
+    toast.success('Opplæring oppdatert')
+    closeDialog()
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const msg = error.response?.data?.error?.message
+      if (typeof msg === 'string' && msg.trim()) {
+        toast.error(msg)
+        return
+      }
+    }
+    toast.error('Kunne ikke oppdatere opplæring')
+  }
 }
 </script>
 
 <template>
-  <Teleport to="body">
-    <Transition name="modal">
-      <div
-        v-if="modelValue"
-        class="overlay"
-        @click.self="close"
-      >
-        <div class="modal">
-          <div class="modal-header">
-            <div class="modal-header-left">
-              <div class="modal-icon">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
-                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
-                </svg>
-              </div>
-              <h2 class="modal-title">Rediger opplæring</h2>
-            </div>
-            <Button variant="ghost" size="icon-sm" class="close-btn" @click="close" aria-label="Lukk">
-              <X :size="16" />
-            </Button>
-          </div>
+  <Dialog :open="open" @update:open="(value) => emits('update:open', value)">
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Rediger opplæring</DialogTitle>
+        <DialogDescription>Oppdater informasjonen for valgt opplæring</DialogDescription>
+      </DialogHeader>
 
-          <div class="modal-body">
-            <div class="field-group">
-              <label class="field-label">Opplæringstype</label>
-              <input v-model="form.type" class="form-input" placeholder="Skriv inn type..." />
-            </div>
-            <div class="field-row">
-              <div class="field-group">
-                <label class="field-label">Fullført dato</label>
-                <input v-model="form.completed" placeholder="dd.mm.åååå" class="form-input" />
-              </div>
-              <div class="field-group">
-                <label class="field-label">Utløpsdato</label>
-                <input v-model="form.expires" placeholder="dd.mm.åååå" class="form-input" />
-              </div>
-            </div>
-            <div class="field-group">
-              <label class="field-label">Status</label>
-              <select v-model="form.status" class="form-input form-select">
-                <option>Gyldig</option>
-                <option>Utløper snart</option>
-                <option>Mangler</option>
-              </select>
-            </div>
-          </div>
+      <form class="form" @submit.prevent="handleSubmit">
+        <label class="field">
+          <span>Ansatt</span>
+          <select v-model="employeeUserId" class="select-field">
+            <option value="" disabled>Velg ansatt…</option>
+            <option v-for="m in members" :key="m.userId" :value="String(m.userId)">
+              {{ m.userFullName }}
+            </option>
+          </select>
+        </label>
 
-          <div class="modal-footer">
-            <div class="footer-left">
-              <button
-                v-if="!deleteConfirm"
-                class="delete-btn"
-                @click="deleteConfirm = true"
-              >
-                <Trash2 :size="13" /> Slett
-              </button>
-              <div v-else class="delete-confirm">
-                <span class="delete-confirm-text">Er du sikker?</span>
-                <button class="confirm-yes" @click="remove">Ja, slett</button>
-                <button class="confirm-no" @click="deleteConfirm = false">Nei</button>
-              </div>
-            </div>
-            <div class="footer-right">
-              <Button variant="destructive" size="sm" @click="close">Avbryt</Button>
-              <Button variant="default" size="sm" @click="save">
-                <Check :size="14" /> Registrer
-              </Button>
-            </div>
-          </div>
+        <label class="field">
+          <span>Opplæringstype *</span>
+          <Input v-model="title" placeholder="Skriv inn type..." />
+        </label>
 
+        <label class="field">
+          <span>Beskrivelse</span>
+          <Textarea v-model="description" rows="3" placeholder="Valgfri beskrivelse..." />
+        </label>
+
+        <div class="field-row">
+          <label class="field">
+            <span>Fullført dato</span>
+            <Input v-model="completedAt" type="date" />
+          </label>
+          <label class="field">
+            <span>Utløpsdato</span>
+            <Input v-model="expiresAt" type="date" />
+          </label>
         </div>
-      </div>
-    </Transition>
-  </Teleport>
+
+        <div class="field">
+          <span>Status</span>
+          <div class="segmented-grid segmented-grid--4">
+            <button
+              v-for="opt in statusOptions"
+              :key="opt.value"
+              type="button"
+              class="segment-button"
+              :class="[
+                `segment-button--${opt.value.toLowerCase()}`,
+                { 'segment-button--active': status === opt.value },
+              ]"
+              @click="status = opt.value"
+            >
+              {{ opt.label }}
+            </button>
+          </div>
+        </div>
+
+        <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" @click="closeDialog">Avbryt</Button>
+          <Button type="submit" :disabled="updateMutation.isPending.value">
+            {{ updateMutation.isPending.value ? 'Lagrer...' : 'Lagre endringer' }}
+          </Button>
+        </DialogFooter>
+      </form>
+    </DialogContent>
+  </Dialog>
 </template>
 
 <style scoped>
-.overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(2px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 50;
-  padding: 16px;
-}
-
-.modal {
-  background: #ffffff;
-  border-radius: 20px;
-  width: 100%;
-  max-width: 440px;
-  box-shadow:
-    0 0 0 1px rgba(0,0,0,0.06),
-    0 8px 24px rgba(0,0,0,0.10),
-    0 24px 64px rgba(0,0,0,0.12);
-  overflow: hidden;
-}
-
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 20px 24px 18px;
-  border-bottom: 1px solid #f0eeee;
-}
-
-.modal-header-left {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.modal-icon {
-  width: 32px;
-  height: 32px;
-  border-radius: 9px;
-  background: #f5f3ff;
-  color: #7c3aed;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-
-.modal-title {
-  font-size: 0.95rem;
-  font-weight: 700;
-  color: #111827;
-  margin: 0;
-  letter-spacing: -0.01em;
-}
-
-.modal-body {
-  padding: 20px 24px;
+.form {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field span {
+  font-size: 0.92rem;
+  font-weight: 600;
 }
 
 .field-row {
@@ -188,138 +205,80 @@ function remove(): void {
   gap: 12px;
 }
 
-.field-group {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.field-label {
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: #6b7280;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.form-input {
-  border: 1.5px solid #e5e7eb;
-  border-radius: 10px;
-  padding: 9px 12px;
-  font-size: 0.875rem;
-  color: #1f2937;
-  background: #fafafa;
-  outline: none;
-  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+.select-field {
   width: 100%;
-  box-sizing: border-box;
-  font-family: inherit;
+  height: 2.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid hsl(var(--input));
+  background: hsl(var(--card));
+  padding: 0 0.75rem;
+  font-size: 0.875rem;
 }
 
-.form-input:focus {
-  border-color: #7c3aed;
-  background: #fff;
-  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.08);
+.select-field:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
+  border-color: hsl(var(--primary) / 0.5);
 }
 
-.form-input::placeholder {
-  color: #d1d5db;
-}
-
-.form-select {
-  appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%239ca3af' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 12px center;
-  padding-right: 32px;
-  cursor: pointer;
-}
-
-.modal-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 24px 20px;
-  border-top: 1px solid #f0eeee;
+.segmented-grid {
+  display: grid;
   gap: 8px;
 }
 
-.footer-left { display: flex; align-items: center; }
-.footer-right { display: flex; align-items: center; gap: 8px; }
-
-.delete-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: #ef4444;
-  background: transparent;
-  border: 1.5px solid #fecaca;
-  border-radius: 9px;
-  padding: 7px 12px;
-  cursor: pointer;
-  transition: background 0.12s, border-color 0.12s;
-}
-.delete-btn:hover {
-  background: #fff5f5;
-  border-color: #fca5a5;
+.segmented-grid--4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
-.delete-confirm {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.delete-confirm-text {
-  font-size: 0.8rem;
-  color: #ef4444;
-  font-weight: 500;
-}
-.confirm-yes {
-  font-size: 0.78rem;
+.segment-button {
+  border: 1px solid hsl(var(--input));
+  background: hsl(var(--card));
+  color: hsl(var(--foreground));
+  border-radius: var(--radius-md);
+  height: 2.5rem;
   font-weight: 600;
-  background: #ef4444;
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  padding: 6px 10px;
   cursor: pointer;
-  transition: background 0.12s;
+  transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
 }
-.confirm-yes:hover { background: #dc2626; }
 
-.confirm-no {
-  font-size: 0.78rem;
-  font-weight: 500;
-  background: transparent;
-  color: #6b7280;
-  border: 1.5px solid #e5e7eb;
-  border-radius: 8px;
-  padding: 5px 10px;
-  cursor: pointer;
-  transition: background 0.12s;
+.segment-button--active {
+  border-color: hsl(var(--primary));
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
 }
-.confirm-no:hover { background: #f9fafb; }
 
-.modal-enter-active,
-.modal-leave-active {
-  transition: opacity 0.2s ease;
+.segment-button--completed.segment-button--active {
+  border-color: #71a66a;
+  background: #dcebd8;
+  color: #2f6f34;
 }
-.modal-enter-active .modal,
-.modal-leave-active .modal {
-  transition: transform 0.22s cubic-bezier(0.34, 1.3, 0.64, 1), opacity 0.2s ease;
+
+.segment-button--expires_soon.segment-button--active {
+  border-color: #d1a768;
+  background: #f4e6d1;
+  color: #d0a11f;
 }
-.modal-enter-from,
-.modal-leave-to {
-  opacity: 0;
+
+.segment-button--expired.segment-button--active {
+  border-color: #d68b3b;
+  background: #f6dfc8;
+  color: #a2550c;
 }
-.modal-enter-from .modal {
-  transform: scale(0.96) translateY(8px);
-  opacity: 0;
+
+.segment-button--not_completed.segment-button--active {
+  border-color: #c95d5d;
+  background: #f4e0e0;
+  color: #902324;
 }
-.modal-leave-to .modal {
-  transform: scale(0.96) translateY(4px);
-  opacity: 0;
+
+.error-message {
+  color: hsl(var(--destructive));
+  font-size: 0.86rem;
+}
+
+@media (max-width: 780px) {
+  .segmented-grid--4 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 </style>

--- a/frontend/src/components/training/RegisterTrainingModal.vue
+++ b/frontend/src/components/training/RegisterTrainingModal.vue
@@ -1,217 +1,188 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
-import { X, Check, ChevronDown } from 'lucide-vue-next'
-import { useTrainingStore } from '@/stores/training'
+import { ref, watch, computed } from 'vue'
+import axios from 'axios'
+import { toast } from 'vue-sonner'
+import Dialog from '@/components/ui/dialog/Dialog.vue'
+import DialogContent from '@/components/ui/dialog/DialogContent.vue'
+import DialogDescription from '@/components/ui/dialog/DialogDescription.vue'
+import DialogFooter from '@/components/ui/dialog/DialogFooter.vue'
+import DialogHeader from '@/components/ui/dialog/DialogHeader.vue'
+import DialogTitle from '@/components/ui/dialog/DialogTitle.vue'
 import Button from '@/components/ui/button/Button.vue'
+import Input from '@/components/ui/input/Input.vue'
+import Textarea from '@/components/ui/textarea/Textarea.vue'
+import {
+  useCreateTrainingLogMutation,
+  useOrganizationMembersQuery,
+} from '@/composables/useTrainingLogs'
+import type { TrainingStatus } from '@/types/training'
 
-defineProps<{ modelValue: boolean }>()
-const emit = defineEmits<{ 'update:modelValue': [value: boolean] }>()
-const store = useTrainingStore()
+const props = defineProps<{ open: boolean }>()
+const emits = defineEmits<{ (e: 'update:open', value: boolean): void }>()
 
-const form = ref({
-  employeeId: null as number | null,
-  type: '',
-  completed: '',
-  expires: '',
-  status: 'Fullført' as 'Fullført' | 'Ikke-fullført',
+const createMutation = useCreateTrainingLogMutation()
+const canManage = computed(() => true)
+const membersQuery = useOrganizationMembersQuery(canManage)
+const members = computed(() => membersQuery.data.value ?? [])
+
+const employeeUserId = ref<string>('')
+const title = ref('')
+const description = ref('')
+const completedAt = ref('')
+const expiresAt = ref('')
+const status = ref<TrainingStatus>('COMPLETED')
+const errorMessage = ref('')
+
+const statusOptions: Array<{ value: TrainingStatus; label: string }> = [
+  { value: 'COMPLETED', label: 'Fullført' },
+  { value: 'NOT_COMPLETED', label: 'Ikke fullført' },
+]
+
+watch(() => props.open, (isOpen) => {
+  if (isOpen) {
+    employeeUserId.value = ''
+    title.value = ''
+    description.value = ''
+    completedAt.value = ''
+    expiresAt.value = ''
+    status.value = 'COMPLETED'
+    errorMessage.value = ''
+  }
 })
 
-const errors = ref<Record<string, string>>({})
-
-const employees = computed(() =>
-  store.employees ?? []
-)
-
-function validate(): boolean {
-  const e: Record<string, string> = {}
-  if (!form.value.employeeId) e.employeeId = 'Velg en ansatt'
-  if (!form.value.type.trim()) e.type = 'Opplæringstype er påkrevd'
-  errors.value = e
-  return Object.keys(e).length === 0
+function closeDialog() {
+  emits('update:open', false)
 }
 
-function close(): void {
-  emit('update:modelValue', false)
-  setTimeout(reset, 300)
+function toIso(dateStr: string): string | undefined {
+  if (!dateStr) return undefined
+  return new Date(dateStr + 'T00:00:00Z').toISOString()
 }
 
-function reset(): void {
-  form.value = { employeeId: null, type: '', completed: '', expires: '', status: 'Fullført' }
-  errors.value = {}
-}
+async function handleSubmit() {
+  const trimmedTitle = title.value.trim()
+  if (!employeeUserId.value) {
+    errorMessage.value = 'Velg en ansatt.'
+    return
+  }
+  if (!trimmedTitle) {
+    errorMessage.value = 'Opplæringstype er påkrevd.'
+    return
+  }
+  errorMessage.value = ''
 
-function save(): void {
-  if (!validate()) return
-  store.addTraining(form.value.employeeId!, {
-    type: form.value.type.trim(),
-    completed: form.value.completed || null,
-    expires: form.value.expires || null,
-    status: form.value.status === 'Ikke-fullført' ? 'Mangler' : 'Gyldig',
-  })
-  close()
+  try {
+    await createMutation.mutateAsync({
+      employeeUserId: Number(employeeUserId.value),
+      title: trimmedTitle,
+      description: description.value.trim() || undefined,
+      completedAt: toIso(completedAt.value),
+      expiresAt: toIso(expiresAt.value),
+      status: status.value,
+    })
+    toast.success('Opplæring registrert')
+    closeDialog()
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const msg = error.response?.data?.error?.message
+      if (typeof msg === 'string' && msg.trim()) {
+        toast.error(msg)
+        return
+      }
+    }
+    toast.error('Kunne ikke registrere opplæring')
+  }
 }
 </script>
 
 <template>
-  <Teleport to="body">
-    <Transition name="modal">
-      <div v-if="modelValue" class="overlay" @click.self="close">
-        <div class="modal">
-          <div class="modal-header">
-            <div class="modal-header-left">
-              <div class="modal-icon">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M12 5v14M5 12h14"/>
-                </svg>
-              </div>
-              <div>
-                <h2 class="modal-title">Registrer opplæring</h2>
-                <p class="modal-sub">Legg til ny opplæring for en ansatt</p>
-              </div>
-            </div>
-            <Button variant="ghost" size="icon-sm" class="close-btn" @click="close" aria-label="Lukk">
-              <X :size="16" />
-            </Button>
-          </div>
+  <Dialog :open="open" @update:open="(value) => emits('update:open', value)">
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Registrer opplæring</DialogTitle>
+        <DialogDescription>Legg til ny opplæring for en ansatt</DialogDescription>
+      </DialogHeader>
 
-          <div class="modal-body">
-            <div class="field-group" :class="{ 'has-error': errors.employeeId }">
-              <label class="field-label">Ansatt <span class="required">*</span></label>
-              <div class="select-wrapper">
-                <select v-model="form.employeeId" class="form-input form-select">
-                  <option :value="null" disabled>Velg ansatt…</option>
-                  <option v-for="emp in employees" :key="emp.id" :value="emp.id">
-                    {{ emp.name }}
-                  </option>
-                </select>
-                <ChevronDown :size="14" class="select-icon" />
-              </div>
-              <span v-if="errors.employeeId" class="error-msg">{{ errors.employeeId }}</span>
-            </div>
-            <div class="field-group" :class="{ 'has-error': errors.type }">
-              <label class="field-label">Opplæringstype <span class="required">*</span></label>
-              <input
-                v-model="form.type"
-                class="form-input"
-                placeholder="F.eks. Brannvern, HMS, Førstehjelp…"
-                @input="delete errors.type"
-              />
-              <span v-if="errors.type" class="error-msg">{{ errors.type }}</span>
-            </div>
-            <div class="field-row">
-              <div class="field-group">
-                <label class="field-label">Fullført dato</label>
-                <input v-model="form.completed" class="form-input" placeholder="dd.mm.åååå" />
-              </div>
-              <div class="field-group">
-                <label class="field-label">Utløpsdato</label>
-                <input v-model="form.expires" class="form-input" placeholder="dd.mm.åååå" />
-              </div>
-            </div>
-            <div class="field-group">
-              <label class="field-label">Status</label>
-              <div class="status-pills">
-                <button
-                  v-for="s in ['Fullført', 'Ikke-fullført']"
-                  :key="s"
-                  type="button"
-                  :class="['status-pill', `pill-${s === 'Ikke-fullført' ? 'ikke-fullfort' : 'fullfort'}`, { active: form.status === s }]"
-                  @click="form.status = s as typeof form.status"
-                >
-                  <span class="pill-dot" />
-                  {{ s }}
-                </button>
-              </div>
-            </div>
+      <form class="form" @submit.prevent="handleSubmit">
+        <label class="field">
+          <span>Ansatt *</span>
+          <select v-model="employeeUserId" class="select-field">
+            <option value="" disabled>Velg ansatt…</option>
+            <option v-for="m in members" :key="m.userId" :value="String(m.userId)">
+              {{ m.userFullName }}
+            </option>
+          </select>
+        </label>
 
-          </div>
+        <label class="field">
+          <span>Opplæringstype *</span>
+          <Input v-model="title" placeholder="F.eks. Brannvern, HMS, Førstehjelp…" />
+        </label>
 
-          <div class="modal-footer">
-            <p class="required-note"><span class="required">*</span> Påkrevde felt</p>
-            <div class="footer-right">
-              <Button variant="destructive" size="sm" @click="close">Avbryt</Button>
-              <Button variant="default" size="sm" @click="save">
-                <Check :size="14" /> Registrer
-              </Button>
-            </div>
-          </div>
+        <label class="field">
+          <span>Beskrivelse</span>
+          <Textarea v-model="description" rows="3" placeholder="Valgfri beskrivelse..." />
+        </label>
 
+        <div class="field-row">
+          <label class="field">
+            <span>Fullført dato</span>
+            <Input v-model="completedAt" type="date" />
+          </label>
+          <label class="field">
+            <span>Utløpsdato</span>
+            <Input v-model="expiresAt" type="date" />
+          </label>
         </div>
-      </div>
-    </Transition>
-  </Teleport>
+
+        <div class="field">
+          <span>Status *</span>
+          <div class="segmented-grid segmented-grid--2">
+            <button
+              v-for="opt in statusOptions"
+              :key="opt.value"
+              type="button"
+              class="segment-button"
+              :class="[
+                `segment-button--${opt.value.toLowerCase()}`,
+                { 'segment-button--active': status === opt.value },
+              ]"
+              @click="status = opt.value"
+            >
+              {{ opt.label }}
+            </button>
+          </div>
+        </div>
+
+        <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" @click="closeDialog">Avbryt</Button>
+          <Button type="submit" :disabled="createMutation.isPending.value">
+            {{ createMutation.isPending.value ? 'Registrerer...' : 'Registrer opplæring' }}
+          </Button>
+        </DialogFooter>
+      </form>
+    </DialogContent>
+  </Dialog>
 </template>
 
 <style scoped>
-.overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(2px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 50;
-  padding: 16px;
-}
-
-.modal {
-  background: #ffffff;
-  border-radius: 20px;
-  width: 100%;
-  max-width: 460px;
-  box-shadow:
-    0 0 0 1px rgba(0,0,0,0.06),
-    0 8px 24px rgba(0,0,0,0.10),
-    0 24px 64px rgba(0,0,0,0.12);
-  overflow: hidden;
-}
-
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 20px 24px 18px;
-  border-bottom: 1px solid #f0eeee;
-}
-
-.modal-header-left {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.modal-icon {
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
-  background: #f5f3ff;
-  color: #7c3aed;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-
-.modal-title {
-  font-size: 0.95rem;
-  font-weight: 700;
-  color: #111827;
-  margin: 0;
-  letter-spacing: -0.01em;
-}
-
-.modal-sub {
-  font-size: 0.75rem;
-  color: #9ca3af;
-  margin: 1px 0 0;
-}
-
-.modal-body {
-  padding: 20px 24px;
+.form {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field span {
+  font-size: 0.92rem;
+  font-weight: 600;
 }
 
 .field-row {
@@ -220,142 +191,62 @@ function save(): void {
   gap: 12px;
 }
 
-.field-group {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.field-label {
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: #6b7280;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.required { color: #7c3aed; }
-
-.form-input {
-  border: 1.5px solid #e5e7eb;
-  border-radius: 10px;
-  padding: 9px 12px;
-  font-size: 0.875rem;
-  color: #1f2937;
-  background: #fafafa;
-  outline: none;
-  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+.select-field {
   width: 100%;
-  box-sizing: border-box;
-  font-family: inherit;
-}
-.form-input:focus {
-  border-color: #7c3aed;
-  background: #fff;
-  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.08);
-}
-.form-input::placeholder { color: #d1d5db; }
-
-.has-error .form-input {
-  border-color: #fca5a5;
-  background: #fff5f5;
-}
-.has-error .form-input:focus {
-  border-color: #ef4444;
-  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.08);
+  height: 2.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid hsl(var(--input));
+  background: hsl(var(--card));
+  padding: 0 0.75rem;
+  font-size: 0.875rem;
 }
 
-.error-msg {
-  font-size: 0.72rem;
-  color: #ef4444;
-  font-weight: 500;
+.select-field:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
+  border-color: hsl(var(--primary) / 0.5);
 }
 
-.select-wrapper {
-  position: relative;
-}
-.form-select {
-  appearance: none;
-  padding-right: 32px;
-  cursor: pointer;
-}
-.select-icon {
-  position: absolute;
-  right: 11px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: #9ca3af;
-  pointer-events: none;
-}
-
-.status-pills {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.status-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  font-weight: 500;
-  cursor: pointer;
-  border: 1.5px solid transparent;
-  background: #f3f4f6;
-  color: #6b7280;
-  transition: all 0.14s;
-  font-family: inherit;
-}
-
-.pill-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: currentColor;
-  opacity: 0.5;
-  transition: opacity 0.14s;
-}
-
-.pill-fullfort { color: #059669; }
-.pill-fullfort:hover { background: #ecfdf5; border-color: #a7f3d0; }
-.pill-fullfort.active { background: #ecfdf5; border-color: #6ee7b7; color: #059669; }
-.pill-fullfort.active .pill-dot { opacity: 1; }
-
-.pill-ikke-fullfort { color: #dc2626; }
-.pill-ikke-fullfort:hover { background: #fff5f5; border-color: #fca5a5; }
-.pill-ikke-fullfort.active { background: #fff5f5; border-color: #fca5a5; color: #dc2626; }
-.pill-ikke-fullfort.active .pill-dot { opacity: 1; }
-
-.modal-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 24px 20px;
-  border-top: 1px solid #f0eeee;
-}
-
-.required-note {
-  font-size: 0.75rem;
-  color: #9ca3af;
-  margin: 0;
-}
-
-.footer-right {
-  display: flex;
-  align-items: center;
+.segmented-grid {
+  display: grid;
   gap: 8px;
 }
 
-.modal-enter-active,
-.modal-leave-active { transition: opacity 0.2s ease; }
-.modal-enter-active .modal,
-.modal-leave-active .modal { transition: transform 0.22s cubic-bezier(0.34, 1.3, 0.64, 1), opacity 0.2s ease; }
-.modal-enter-from,
-.modal-leave-to { opacity: 0; }
-.modal-enter-from .modal { transform: scale(0.96) translateY(8px); opacity: 0; }
-.modal-leave-to .modal { transform: scale(0.96) translateY(4px); opacity: 0; }
+.segmented-grid--2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
 
+.segment-button {
+  border: 1px solid hsl(var(--input));
+  background: hsl(var(--card));
+  color: hsl(var(--foreground));
+  border-radius: var(--radius-md);
+  height: 2.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
+}
+
+.segment-button--active {
+  border-color: hsl(var(--primary));
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+.segment-button--completed.segment-button--active {
+  border-color: #71a66a;
+  background: #dcebd8;
+  color: #2f6f34;
+}
+
+.segment-button--not_completed.segment-button--active {
+  border-color: #c95d5d;
+  background: #f4e0e0;
+  color: #902324;
+}
+
+.error-message {
+  color: hsl(var(--destructive));
+  font-size: 0.86rem;
+}
 </style>

--- a/frontend/src/components/training/StatusBadge.vue
+++ b/frontend/src/components/training/StatusBadge.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
-import type { Training } from '@/stores/training'
-defineProps<{ status: Training['status'] }>()
+defineProps<{ status: string }>()
 </script>
 
 <template>
   <span class="badge" :class="{
     'badge-green':  status === 'Gyldig',
     'badge-amber':  status === 'Utløper snart',
-    'badge-red':    status === 'Mangler',
+    'badge-red':    status === 'Mangler' || status === 'Utgått',
   }">
     {{ status }}
   </span>

--- a/frontend/src/composables/useTrainingLogs.ts
+++ b/frontend/src/composables/useTrainingLogs.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query'
+import api from '@/lib/api'
+import type {
+  CreateTrainingLogRequest,
+  TrainingLog,
+  UpdateTrainingLogRequest,
+} from '@/types/training'
+
+export { useMembersQuery as useOrganizationMembersQuery } from './useMembers'
+
+const trainingLogsQueryKey = ['training-logs']
+
+export function useTrainingLogsQuery() {
+  return useQuery({
+    queryKey: trainingLogsQueryKey,
+    queryFn: () => api.get<TrainingLog[]>('/training-logs').then((r) => r.data),
+  })
+}
+
+export function useCreateTrainingLogMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (payload: CreateTrainingLogRequest) =>
+      api.post<TrainingLog>('/training-logs', payload).then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: trainingLogsQueryKey })
+    },
+  })
+}
+
+export function useUpdateTrainingLogMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: number; payload: UpdateTrainingLogRequest }) =>
+      api.patch<TrainingLog>(`/training-logs/${id}`, payload).then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: trainingLogsQueryKey })
+    },
+  })
+}
+
+export function useDeleteTrainingLogMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: number) => api.delete(`/training-logs/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: trainingLogsQueryKey })
+    },
+  })
+}

--- a/frontend/src/types/training.ts
+++ b/frontend/src/types/training.ts
@@ -1,0 +1,35 @@
+export type TrainingStatus = 'COMPLETED' | 'EXPIRES_SOON' | 'EXPIRED' | 'NOT_COMPLETED'
+
+export interface TrainingLog {
+  id: number
+  organizationId: number
+  employeeUserId: number
+  employeeUserName: string
+  loggedByUserId: number
+  loggedByUserName: string
+  title: string
+  description: string | null
+  completedAt: string | null
+  expiresAt: string | null
+  status: TrainingStatus
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateTrainingLogRequest {
+  employeeUserId: number
+  title: string
+  description?: string
+  completedAt?: string
+  expiresAt?: string
+  status: TrainingStatus
+}
+
+export interface UpdateTrainingLogRequest {
+  employeeUserId?: number
+  title?: string
+  description?: string
+  completedAt?: string
+  expiresAt?: string
+  status?: TrainingStatus
+}

--- a/frontend/src/views/AdminTrainingView.vue
+++ b/frontend/src/views/AdminTrainingView.vue
@@ -1,504 +1,686 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
-import { Plus, Pencil, X, Trash2 } from 'lucide-vue-next'
-import type { TrainingRow } from '@/stores/training'
-import { useTrainingStore } from '@/stores/training'
-import StatCard from '@/components/training/StatCard.vue'
+import { computed, ref } from 'vue'
+import axios from 'axios'
+import { MoreVertical, ArrowUpDown, Search, Plus, Pencil, Trash2, AlertTriangle } from 'lucide-vue-next'
+import { toast } from 'vue-sonner'
+import { Separator } from '@/components/ui/separator'
+import { SidebarTrigger } from '@/components/ui/sidebar'
+import Button from '@/components/ui/button/Button.vue'
+import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableEmpty,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu'
+import AlertDialog from '@/components/ui/alert-dialog/AlertDialog.vue'
+import AlertDialogAction from '@/components/ui/alert-dialog/AlertDialogAction.vue'
+import AlertDialogCancel from '@/components/ui/alert-dialog/AlertDialogCancel.vue'
+import AlertDialogContent from '@/components/ui/alert-dialog/AlertDialogContent.vue'
+import AlertDialogDescription from '@/components/ui/alert-dialog/AlertDialogDescription.vue'
+import AlertDialogFooter from '@/components/ui/alert-dialog/AlertDialogFooter.vue'
+import AlertDialogHeader from '@/components/ui/alert-dialog/AlertDialogHeader.vue'
+import AlertDialogTitle from '@/components/ui/alert-dialog/AlertDialogTitle.vue'
 import StatusBadge from '@/components/training/StatusBadge.vue'
-import EmployeeAvatar from '@/components/training/EmployeeAvatar.vue'
-import FilterPanel from '@/components/training/FilterPanel.vue'
-import EditTrainingModal from '@/components/training/EditTrainingModal.vue'
 import RegisterTrainingModal from '@/components/training/RegisterTrainingModal.vue'
+import EditTrainingModal from '@/components/training/EditTrainingModal.vue'
+import {
+  useTrainingLogsQuery,
+  useDeleteTrainingLogMutation,
+} from '@/composables/useTrainingLogs'
+import type { TrainingLog, TrainingStatus } from '@/types/training'
 
-const store = useTrainingStore()
+const trainingLogsQuery = useTrainingLogsQuery()
+const deleteTrainingLog = useDeleteTrainingLogMutation()
 
-const filterType   = ref('')
-const filterStatus = ref('')
+const trainingLogs = computed(() => trainingLogsQuery.data.value ?? [])
 
-type SortDir = 'none' | 'asc' | 'desc'
-const nameSortDir = ref<SortDir>('none')
+// ── Search ──
+const search = ref('')
 
-function cycleNameSort(): void {
-  if (nameSortDir.value === 'none') { nameSortDir.value = 'asc' }
-  else if (nameSortDir.value === 'asc') { nameSortDir.value = 'desc' }
-  else { nameSortDir.value = 'none' }
+// ── Sorting ──
+type SortField = 'employee' | 'title' | 'completed' | 'expires' | 'status'
+type SortDir = 'asc' | 'desc'
+const sortField = ref<SortField>('employee')
+const sortDir = ref<SortDir>('asc')
+
+function toggleSort(field: SortField) {
+  if (sortField.value === field) {
+    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortField.value = field
+    sortDir.value = 'asc'
+  }
 }
 
-const filtered = computed(() => {
-  const rows = store.allTrainings.filter(t =>
-    (!filterType.value   || t.type   === filterType.value) &&
-    (!filterStatus.value || t.status === filterStatus.value)
-  )
-  if (nameSortDir.value === 'none') return rows
-  return [...rows].sort((a, b) => {
-    const cmp = a.employee.name.localeCompare(b.employee.name, 'nb')
-    return nameSortDir.value === 'asc' ? cmp : -cmp
+const statusLabel: Record<TrainingStatus, string> = {
+  COMPLETED: 'Gyldig',
+  EXPIRES_SOON: 'Utløper snart',
+  EXPIRED: 'Utgått',
+  NOT_COMPLETED: 'Mangler',
+}
+
+const statusOrder: Record<TrainingStatus, number> = {
+  NOT_COMPLETED: 0,
+  EXPIRED: 1,
+  EXPIRES_SOON: 2,
+  COMPLETED: 3,
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return d.toLocaleDateString('nb-NO', { day: '2-digit', month: '2-digit', year: 'numeric' })
+}
+
+const filteredAndSorted = computed(() => {
+  const q = search.value.toLowerCase().trim()
+  let list = trainingLogs.value.slice()
+
+  if (q) {
+    list = list.filter((t) =>
+      [t.employeeUserName, t.title, statusLabel[t.status]].some((v) =>
+        v.toLowerCase().includes(q),
+      ),
+    )
+  }
+
+  list.sort((a, b) => {
+    let cmp = 0
+    if (sortField.value === 'employee') {
+      cmp = a.employeeUserName.localeCompare(b.employeeUserName, 'nb')
+    } else if (sortField.value === 'title') {
+      cmp = a.title.localeCompare(b.title, 'nb')
+    } else if (sortField.value === 'completed') {
+      cmp = (a.completedAt ?? '').localeCompare(b.completedAt ?? '')
+    } else if (sortField.value === 'expires') {
+      cmp = (a.expiresAt ?? '').localeCompare(b.expiresAt ?? '')
+    } else if (sortField.value === 'status') {
+      cmp = statusOrder[a.status] - statusOrder[b.status]
+    }
+    return sortDir.value === 'desc' ? -cmp : cmp
   })
+
+  return list
 })
 
-const editMode = ref(false)
+// ── Checkbox selection ──
 const selected = ref<Set<number>>(new Set())
 
-function toggleEditMode(): void {
-  editMode.value = !editMode.value
-  selected.value = new Set()
-}
-
-function toggleSelect(id: number): void {
+function toggleSelect(id: number) {
   const s = new Set(selected.value)
-  if (s.has(id)) { s.delete(id) } else { s.add(id) }
+  if (s.has(id)) s.delete(id)
+  else s.add(id)
   selected.value = s
 }
 
 const allSelected = computed(() =>
-  filtered.value.length > 0 && filtered.value.every(r => selected.value.has(r.id))
+  filteredAndSorted.value.length > 0 &&
+  filteredAndSorted.value.every((r) => selected.value.has(r.id)),
 )
 
-function toggleSelectAll(): void {
+function toggleSelectAll() {
   selected.value = allSelected.value
     ? new Set()
-    : new Set(filtered.value.map(r => r.id))
+    : new Set(filteredAndSorted.value.map((r) => r.id))
 }
 
-function deleteSelected(): void {
-  selected.value.forEach(id => {
-    const row = store.allTrainings.find(r => r.id === id)
-    if (row) store.deleteTraining(row.employee.id, row.id)
-  })
-  selected.value = new Set()
-  editMode.value = false
+// ── Stats ──
+const stats = computed(() => {
+  const list = trainingLogs.value
+  return {
+    total: list.length,
+    completed: list.filter((t) => t.status === 'COMPLETED').length,
+    expiringSoon: list.filter((t) => t.status === 'EXPIRES_SOON').length,
+    expired: list.filter((t) => t.status === 'EXPIRED').length,
+    notCompleted: list.filter((t) => t.status === 'NOT_COMPLETED').length,
+  }
+})
+
+// ── Register modal ──
+const showRegister = ref(false)
+
+// ── Edit modal ──
+const editModalOpen = ref(false)
+const editingLog = ref<TrainingLog | null>(null)
+
+function openEdit(log: TrainingLog) {
+  editingLog.value = log
+  editModalOpen.value = true
 }
 
-const showRegister     = ref(false)
-const editModal        = ref(false)
-const editRow          = ref<TrainingRow | null>(null)
-const deleteConfirmRow = ref<TrainingRow | null>(null)
+// ── Delete ──
+const deleteDialogOpen = ref(false)
+const deletingIds = ref<number[]>([])
 
-function openEdit(row: TrainingRow): void {
-  editRow.value   = row
-  editModal.value = true
+function openDeleteSingle(log: TrainingLog) {
+  deletingIds.value = [log.id]
+  deleteDialogOpen.value = true
 }
 
-function confirmDelete(): void {
-  if (!deleteConfirmRow.value) return
-  store.deleteTraining(deleteConfirmRow.value.employee.id, deleteConfirmRow.value.id)
-  deleteConfirmRow.value = null
+function openDeleteSelected() {
+  deletingIds.value = [...selected.value]
+  deleteDialogOpen.value = true
+}
+
+async function confirmDelete() {
+  try {
+    for (const id of deletingIds.value) {
+      await deleteTrainingLog.mutateAsync(id)
+    }
+    toast.success(`Slettet ${deletingIds.value.length} opplæring${deletingIds.value.length > 1 ? 'er' : ''}`)
+    selected.value = new Set()
+  } catch (error) {
+    handleMutationError(error, 'Kunne ikke slette opplæring')
+  } finally {
+    deleteDialogOpen.value = false
+    deletingIds.value = []
+  }
+}
+
+function handleMutationError(error: unknown, fallbackMessage: string) {
+  if (axios.isAxiosError(error)) {
+    const message = error.response?.data?.error?.message
+    if (typeof message === 'string' && message.trim().length > 0) {
+      toast.error(message)
+      return
+    }
+  }
+  toast.error(fallbackMessage)
 }
 </script>
 
 <template>
-  <div class="page">
-    <div class="header">
+  <header class="page-header">
+    <div class="page-header-inner">
+      <SidebarTrigger />
+      <Separator orientation="vertical" class="header-separator" />
+      <span class="page-title">Opplæring</span>
+    </div>
+  </header>
+
+  <div class="page-content">
+    <section class="header-row">
       <div>
-        <h1 class="page-title">Opplæring og sertifiseringer</h1>
-        <p class="page-sub">Oversikt over ansattes opplæringsstatus</p>
+        <h1>Opplæring og sertifiseringer</h1>
+        <p>Oversikt over ansattes opplæringsstatus</p>
       </div>
       <div class="header-actions">
-        <button v-if="!editMode" class="btn btn-outline" @click="toggleEditMode">
-          <Pencil :size="14" /> Rediger
-        </button>
-        <template v-else>
-          <button v-if="selected.size > 0" class="btn btn-danger" @click="deleteSelected">
-            <Trash2 :size="14" /> Slett ({{ selected.size }})
-          </button>
-          <button class="btn btn-outline" @click="toggleEditMode">
-            <X :size="14" /> Avbryt
-          </button>
-        </template>
-        <button v-if="!editMode" class="btn btn-register" @click="showRegister = true">
-          <Plus :size="15" /> Registrer opplæring
-        </button>
+        <Button
+          v-if="selected.size > 0"
+          variant="destructive"
+          @click="openDeleteSelected"
+        >
+          <Trash2 :size="16" />
+          Slett ({{ selected.size }})
+        </Button>
+        <Button @click="showRegister = true">
+          <Plus :size="16" />
+          Registrer opplæring
+        </Button>
       </div>
-    </div>
-    <div class="stat-grid">
-      <StatCard label="Totalt ansatte" :value="store.totalEmployees" />
-      <StatCard
-        label="Fullført opplæring"
-        :value="`${store.completedCount} / ${store.totalEmployees}`"
-        value-class="val-green"
-      >
-        <div class="progress-track">
-          <div
-            class="progress-bar"
-            :style="{ width: (store.completedCount / store.totalEmployees * 100) + '%' }"
-          />
-        </div>
-      </StatCard>
-      <StatCard
-        label="Utløper snart"
-        :value="store.expiringSoonCount"
-        value-class="val-amber"
-        sub-label="Innen 30 dager"
-      />
-    </div>
-    <FilterPanel
-      :types="store.trainingTypes"
-      v-model:modelType="filterType"
-      v-model:modelStatus="filterStatus"
-    />
-    <div class="table-card">
-      <div v-if="!filtered.length" class="empty-state">
-        Ingen resultater matcher filteret.
+    </section>
+
+    <!-- Stats cards -->
+    <section class="cards-group">
+      <article class="status-card">
+        <span>Totalt opplærte</span>
+        <strong>{{ stats.total }}</strong>
+      </article>
+      <article class="status-card status-card--completed">
+        <span>Fullført</span>
+        <strong>{{ stats.completed }}</strong>
+      </article>
+      <article class="status-card status-card--expiring">
+        <span>Utløper snart</span>
+        <strong>{{ stats.expiringSoon }}</strong>
+      </article>
+      <article class="status-card status-card--expired">
+        <span>Utgått</span>
+        <strong>{{ stats.expired }}</strong>
+      </article>
+      <article class="status-card status-card--missing">
+        <span>Mangler</span>
+        <strong>{{ stats.notCompleted }}</strong>
+      </article>
+    </section>
+
+    <!-- Table -->
+    <section class="table-section">
+      <div class="search-wrapper">
+        <Search :size="16" class="search-icon" />
+        <input v-model="search" class="search-input" placeholder="Søk etter ansatt, type eller status..." />
       </div>
 
-      <div v-else class="table-scroll">
-        <table class="data-table">
-          <thead>
-          <tr>
-            <th v-if="editMode" class="col-check">
-              <input
-                type="checkbox"
-                :checked="allSelected"
-                @change="toggleSelectAll"
-              />
-            </th>
-            <th class="th-sortable" @click="cycleNameSort">
-              Ansatt
-              <span class="sort-icon">
-                  <span :class="['arrow', nameSortDir === 'asc' ? 'arrow-active' : '']">▲</span>
-                  <span :class="['arrow', nameSortDir === 'desc' ? 'arrow-active' : '']">▼</span>
-                </span>
-            </th>
-            <th class="hide-mobile">Opplæringstype</th>
-            <th class="hide-mobile">Fullført</th>
-            <th>Utløper</th>
-            <th>Status</th>
-            <th v-if="!editMode" class="col-action" />
-          </tr>
-          </thead>
-          <tbody>
-          <tr
-            v-for="row in filtered"
-            :key="row.id"
-            :class="{ 'row-selected': editMode && selected.has(row.id), 'row-clickable': editMode }"
-            @click="editMode && toggleSelect(row.id)"
-          >
-            <td v-if="editMode" class="col-check">
-              <input
-                type="checkbox"
-                :checked="selected.has(row.id)"
-                @click.stop
-                @change="toggleSelect(row.id)"
-              />
-            </td>
+      <p v-if="trainingLogsQuery.isLoading.value" class="state-line">Laster opplæringer...</p>
 
-            <td>
-              <div class="employee-cell">
-                <EmployeeAvatar :initials="row.employee.initials" :color="row.employee.color" size="sm" />
-                <div>
-                  <p class="emp-name">{{ row.employee.name }}</p>
-                  <p class="emp-role">{{ row.employee.role }}</p>
-                </div>
-              </div>
-            </td>
-
-            <td class="hide-mobile cell-text">{{ row.type }}</td>
-            <td class="hide-mobile cell-text">{{ row.completed ?? '—' }}</td>
-
-            <td :class="['cell-text', row.status === 'Utløper snart' ? 'expires-soon' : '']">
-              {{ row.expires ?? '—' }}
-            </td>
-
-            <td><StatusBadge :status="row.status" /></td>
-
-            <td v-if="!editMode" class="col-action">
-              <button class="icon-btn" aria-label="Rediger" @click.stop="openEdit(row)">
-                <Pencil :size="14" />
-              </button>
-            </td>
-          </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-
-    <!-- Modals -->
-    <EditTrainingModal
-      v-model="editModal"
-      :training="editRow"
-      :employee-id="editRow?.employee?.id"
-    />
-    <RegisterTrainingModal v-model="showRegister" />
-
-    <Teleport to="body">
-      <div v-if="deleteConfirmRow" class="overlay" @click.self="deleteConfirmRow = null">
-        <div class="dialog">
-          <h2 class="dialog-title">Slett opplæring</h2>
-          <p class="dialog-body">
-            Er du sikker på at du vil slette
-            <strong>{{ deleteConfirmRow.type }}</strong> for
-            <strong>{{ deleteConfirmRow.employee.name }}</strong>?
-            Dette kan ikke angres.
-          </p>
-          <div class="dialog-actions">
-            <button class="btn btn-outline" @click="deleteConfirmRow = null">Avbryt</button>
-            <button class="btn btn-danger" @click="confirmDelete">Slett</button>
+      <div v-else-if="trainingLogsQuery.isError.value" class="empty-state">
+        <div class="empty-state-bg" />
+        <div class="empty-state-inner">
+          <div class="empty-state-icon">
+            <AlertTriangle :stroke-width="1.5" />
+          </div>
+          <div class="empty-state-text">
+            <h3>Kunne ikke hente opplæringer</h3>
+            <p>Noe gikk galt under lasting. Prøv igjen senere.</p>
           </div>
         </div>
       </div>
-    </Teleport>
 
+      <div v-else class="table-card">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead class="th-check">
+                <Checkbox :checked="allSelected" @update:checked="toggleSelectAll" />
+              </TableHead>
+              <TableHead class="th-employee">
+                <button class="sort-btn" @click="toggleSort('employee')">
+                  Ansatt
+                  <ArrowUpDown :size="14" class="sort-icon" :class="{ 'sort-icon--active': sortField === 'employee' }" />
+                </button>
+              </TableHead>
+              <TableHead class="th-title">
+                <button class="sort-btn" @click="toggleSort('title')">
+                  Opplæringstype
+                  <ArrowUpDown :size="14" class="sort-icon" :class="{ 'sort-icon--active': sortField === 'title' }" />
+                </button>
+              </TableHead>
+              <TableHead class="th-date hide-mobile">
+                <button class="sort-btn" @click="toggleSort('completed')">
+                  Fullført
+                  <ArrowUpDown :size="14" class="sort-icon" :class="{ 'sort-icon--active': sortField === 'completed' }" />
+                </button>
+              </TableHead>
+              <TableHead class="th-date hide-mobile">
+                <button class="sort-btn" @click="toggleSort('expires')">
+                  Utløper
+                  <ArrowUpDown :size="14" class="sort-icon" :class="{ 'sort-icon--active': sortField === 'expires' }" />
+                </button>
+              </TableHead>
+              <TableHead class="th-status">
+                <button class="sort-btn" @click="toggleSort('status')">
+                  Status
+                  <ArrowUpDown :size="14" class="sort-icon" :class="{ 'sort-icon--active': sortField === 'status' }" />
+                </button>
+              </TableHead>
+              <TableHead class="th-actions" />
+            </TableRow>
+          </TableHeader>
+
+          <TableBody>
+            <TableRow
+              v-for="log in filteredAndSorted"
+              :key="log.id"
+              :class="selected.has(log.id) ? 'row-selected' : ''"
+            >
+              <TableCell class="td-check">
+                <Checkbox :checked="selected.has(log.id)" @update:checked="toggleSelect(log.id)" />
+              </TableCell>
+              <TableCell>
+                <div class="cell-user">
+                  <div class="user-avatar">
+                    {{ log.employeeUserName.split(' ').slice(0, 2).map(w => w[0]).join('').toUpperCase() }}
+                  </div>
+                  <span class="user-name">{{ log.employeeUserName }}</span>
+                </div>
+              </TableCell>
+              <TableCell class="cell-text">{{ log.title }}</TableCell>
+              <TableCell class="cell-text hide-mobile">{{ formatDate(log.completedAt) }}</TableCell>
+              <TableCell :class="`cell-text hide-mobile${log.status === 'EXPIRES_SOON' ? ' cell-expires-soon' : ''}`">
+                {{ formatDate(log.expiresAt) }}
+              </TableCell>
+              <TableCell>
+                <StatusBadge :status="statusLabel[log.status]" />
+              </TableCell>
+              <TableCell class="cell-actions">
+                <DropdownMenu>
+                  <DropdownMenuTrigger as-child>
+                    <button type="button" class="actions-trigger">
+                      <MoreVertical :size="18" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" :side-offset="4">
+                    <DropdownMenuLabel>Handlinger</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem @click="openEdit(log)">
+                      <Pencil :size="16" />
+                      Rediger
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem class="menu-item--danger" @click="openDeleteSingle(log)">
+                      <Trash2 :size="16" />
+                      Slett
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </TableCell>
+            </TableRow>
+
+            <TableEmpty v-if="filteredAndSorted.length === 0" :colspan="7">
+              Ingen opplæringer matcher søket.
+            </TableEmpty>
+          </TableBody>
+        </Table>
+      </div>
+    </section>
+
+    <!-- Modals -->
+    <RegisterTrainingModal :open="showRegister" @update:open="(v) => { showRegister = v }" />
+    <EditTrainingModal
+      :open="editModalOpen"
+      :training="editingLog"
+      @update:open="(v) => { editModalOpen = v }"
+    />
+
+    <!-- Delete confirmation dialog -->
+    <AlertDialog :open="deleteDialogOpen" @update:open="(v: boolean) => { deleteDialogOpen = v }">
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Slett opplæring?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {{ deletingIds.length === 1
+              ? 'Er du sikker på at du vil slette denne opplæringen? Dette kan ikke angres.'
+              : `Er du sikker på at du vil slette ${deletingIds.length} opplæringer? Dette kan ikke angres.`
+            }}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Avbryt</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" @click="confirmDelete">Slett</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   </div>
 </template>
 
 <style scoped>
-.page {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 28px 24px 64px;
-  font-family: inherit;
-}
+.page-header { display: flex; height: 4rem; flex-shrink: 0; align-items: center; }
+.page-header-inner { display: flex; align-items: center; gap: 0.5rem; padding: 0 1rem; }
+.header-separator { height: 1rem !important; width: 1px !important; margin-right: 0.5rem; }
+.page-title { font-weight: 500; color: hsl(var(--sidebar-primary, 245 43% 52%)); }
+.page-content { display: flex; flex: 1; flex-direction: column; gap: 1rem; padding: 0 1rem 1rem; }
 
-.header {
+.header-row {
   display: flex;
-  align-items: flex-start;
   justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-bottom: 28px;
-}
-
-.page-title {
-  font-size: 1.6rem;
-  font-weight: 700;
-  color: #111827;
-  margin: 0;
-  letter-spacing: -0.02em;
-}
-
-.page-sub {
-  font-size: 0.85rem;
-  color: #9ca3af;
-  margin: 2px 0 0;
+  align-items: flex-start;
+  gap: 1rem;
 }
 
 .header-actions {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
 }
 
-.btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 9px 16px;
-  border-radius: 12px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
-  border: none;
-}
+h1 { margin: 0; font-size: 2.4rem; letter-spacing: -0.02em; }
+.header-row p { margin-top: 6px; color: var(--text-secondary); font-size: 1.08rem; }
 
-.btn-outline {
-  background: #fff;
-  border: 1px solid #e7e5e4;
-  color: #4b5563;
-}
-.btn-outline:hover { background: #f5f5f4; }
-
-.btn-register {
-  background: #fff;
-  border: 1px solid #e7e5e4;
-  color: #4f46e5;
-}
-.btn-register:hover { background: #eef2ff; }
-
-.btn-danger {
-  background: #dc2626;
-  border: 1px solid #dc2626;
-  color: #fff;
-}
-.btn-danger:hover { background: #b91c1c; }
-
-.stat-grid {
+/* Stats cards */
+.cards-group {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
-  margin-bottom: 24px;
-}
-
-@media (max-width: 600px) {
-  .stat-grid { grid-template-columns: repeat(2, 1fr); }
-}
-
-.progress-track {
-  margin-top: 10px;
-  height: 6px;
-  background: #f0fdf4;
-  border-radius: 999px;
-  overflow: hidden;
-}
-.progress-bar {
-  height: 100%;
-  background: #059669;
-  border-radius: 999px;
-  transition: width 0.5s ease;
-}
-
-.table-card {
-  background: #fff;
-  border: 1px solid #e7e5e4;
-  border-radius: 16px;
-  overflow: hidden;
-}
-
-.table-scroll { overflow-x: auto; }
-
-.empty-state {
-  padding: 64px 0;
-  text-align: center;
-  font-size: 0.875rem;
-  color: #9ca3af;
-}
-
-.data-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.data-table thead tr {
-  border-bottom: 1px solid #f5f5f4;
-}
-
-.data-table th {
-  text-align: left;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: #9ca3af;
-  padding: 12px 20px;
-  white-space: nowrap;
-}
-
-.th-sortable {
-  cursor: pointer;
-  user-select: none;
-}
-.th-sortable:hover { color: #374151; }
-
-.sort-icon {
-  display: inline-flex;
-  flex-direction: column;
-  gap: 1px;
-  margin-left: 5px;
-  vertical-align: middle;
-  line-height: 1;
-}
-
-.arrow {
-  font-size: 0.5rem;
-  color: #d1d5db;
-  line-height: 1;
-}
-.arrow-active { color: #059669; }
-
-.data-table tbody tr {
-  border-bottom: 1px solid #fafaf9;
-  transition: background 0.12s;
-}
-.data-table tbody tr:last-child { border-bottom: none; }
-.data-table tbody tr:hover { background: #fafaf9; }
-
-.data-table td {
-  padding: 14px 20px;
-  vertical-align: middle;
-}
-
-.col-check {
-  width: 44px;
-  padding-left: 16px;
-  padding-right: 8px;
-}
-.col-check input[type="checkbox"] {
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
-  accent-color: #059669;
-}
-
-.col-action { width: 40px; padding: 0 12px; }
-
-.row-selected { background: #fff1f2 !important; }
-.row-clickable { cursor: pointer; }
-
-.cell-text { font-size: 0.875rem; color: #4b5563; }
-.expires-soon { color: #d97706; font-weight: 600; }
-
-.employee-cell {
-  display: flex;
-  align-items: center;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 10px;
 }
-.emp-name {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: #111827;
-  margin: 0;
-}
-.emp-role {
-  font-size: 0.75rem;
-  color: #9ca3af;
-  margin: 0;
+
+.status-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--card-bg);
 }
 
-.icon-btn {
-  width: 28px;
-  height: 28px;
+.status-card span { font-size: 1rem; }
+.status-card strong { font-size: 2rem; letter-spacing: -0.02em; }
+
+.status-card--completed {
+  background: #f3faf2;
+  border-color: #c8e4c2;
+}
+.status-card--completed strong { color: #3c8f2c; }
+
+.status-card--expiring {
+  background: #fdf9f0;
+  border-color: #f0ddb0;
+}
+.status-card--expiring strong { color: #946013; }
+
+.status-card--expired {
+  background: #fdf5f5;
+  border-color: #f0d0d0;
+}
+.status-card--expired strong { color: #a62929; }
+
+.status-card--missing {
+  background: #fdf5f5;
+  border-color: #f0d0d0;
+}
+.status-card--missing strong { color: #a62929; }
+
+/* Search */
+.search-wrapper {
+  position: relative;
+  width: 20rem;
+}
+
+.search-icon {
+  position: absolute;
+  left: 0.65rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: hsl(var(--muted-foreground, 24 5% 46%));
+  pointer-events: none;
+}
+
+.search-input {
+  width: 100%;
+  border: 1px solid hsl(var(--border, 35 18% 88%));
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem 0.5rem 2.1rem;
+  font: inherit;
+  font-size: 0.85rem;
+  background: hsl(var(--card, 40 25% 98%));
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: hsl(var(--ring, 245 43% 52%));
+  box-shadow: 0 0 0 2px hsl(var(--ring, 245 43% 52%) / 0.15);
+}
+
+/* Table */
+.table-section { display: flex; flex-direction: column; gap: 0.75rem; }
+
+.table-card {
+  border: 1px solid hsl(var(--border, 35 18% 88%));
+  border-radius: 0.75rem;
+  background: hsl(var(--card, 40 25% 98%));
+}
+
+/* Sort buttons */
+.sort-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: none;
   border: none;
-  background: transparent;
-  border-radius: 8px;
+  font: inherit;
+  font-weight: 500;
+  color: hsl(var(--muted-foreground, 24 5% 46%));
+  cursor: pointer;
+  padding: 0.25rem 0.4rem;
+  border-radius: var(--radius-md, 0.375rem);
+  margin: -0.25rem -0.4rem;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.sort-btn:hover {
+  background: hsl(var(--accent, 250 40% 95%));
+  color: hsl(var(--foreground, 24 10% 15%));
+}
+
+.sort-icon { opacity: 0.4; transition: opacity 150ms; }
+.sort-icon--active { opacity: 1; }
+
+/* Checkbox */
+.th-check, .td-check { width: 3rem; padding-left: 1rem; padding-right: 0; }
+
+/* Row selection */
+.row-selected {
+  background-color: hsl(var(--muted, 40 18% 93%) / 0.6) !important;
+}
+
+/* User cell */
+.cell-user {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.user-avatar {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9999px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #d1d5db;
-  cursor: pointer;
-  transition: background 0.12s, color 0.12s;
+  background: hsl(var(--muted, 40 18% 93%));
+  color: hsl(var(--muted-foreground, 24 5% 46%));
+  font-size: 0.75rem;
+  font-weight: 600;
+  flex-shrink: 0;
 }
-.icon-btn:hover { background: #f5f5f4; color: #374151; }
+
+.user-name { font-weight: 500; }
+.cell-text { color: hsl(var(--muted-foreground, 24 5% 46%)); }
+.cell-expires-soon { color: #d97706; font-weight: 600; }
+
+/* Actions cell */
+.cell-actions {
+  width: 3rem;
+  text-align: right;
+}
+
+.actions-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-md, 0.375rem);
+  border: none;
+  background: none;
+  color: hsl(var(--muted-foreground, 24 5% 46%));
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.actions-trigger:hover {
+  background: hsl(var(--accent, 250 40% 95%));
+  color: hsl(var(--foreground, 24 10% 15%));
+}
+
+.menu-item--danger { color: #dc2626; }
+
+/* Column widths */
+.th-employee { min-width: 10rem; }
+.th-title { min-width: 8rem; }
+.th-date { min-width: 6rem; }
+.th-status { min-width: 6rem; }
+.th-actions { width: 3rem; }
+
+/* Loading / Error states */
+.state-line {
+  border-radius: var(--radius-md);
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  padding: 12px;
+  color: var(--text-secondary);
+}
+
+.empty-state {
+  position: relative;
+  display: flex;
+  min-height: 260px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 1rem;
+  border: 2px dashed hsl(var(--muted-foreground) / 0.2);
+  background: linear-gradient(to bottom right, hsl(var(--muted) / 0.4), hsl(var(--muted) / 0.2), hsl(var(--background)));
+  padding: 2rem;
+}
+
+.empty-state-bg {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at center, hsl(var(--muted)) 0%, transparent 70%);
+  opacity: 0.5;
+}
+
+.empty-state-inner {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
+}
+
+.empty-state-icon {
+  display: flex;
+  height: 5rem;
+  width: 5rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 1rem;
+  background-color: hsl(var(--primary) / 0.1);
+  box-shadow: 0 0 0 4px hsl(var(--primary) / 0.05);
+}
+
+.empty-state-icon :deep(svg) {
+  width: 2.5rem;
+  height: 2.5rem;
+  color: hsl(var(--primary) / 0.7);
+}
+
+.empty-state-text h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.empty-state-text p {
+  max-width: 24rem;
+  font-size: 0.875rem;
+  color: hsl(var(--muted-foreground));
+  margin-top: 0.25rem;
+}
+
+@media (max-width: 1100px) {
+  .cards-group { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
 
 @media (max-width: 768px) {
   .hide-mobile { display: none; }
-}
-
-.overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 50;
-  padding: 16px;
-}
-
-.dialog {
-  background: #fff;
-  border-radius: 16px;
-  width: 100%;
-  max-width: 380px;
-  padding: 24px;
-  box-shadow: 0 20px 60px rgba(0,0,0,0.15);
-}
-
-.dialog-title {
-  font-size: 1rem;
-  font-weight: 700;
-  color: #111827;
-  margin: 0 0 6px;
-}
-
-.dialog-body {
-  font-size: 0.875rem;
-  color: #6b7280;
-  margin: 0 0 20px;
-  line-height: 1.5;
-}
-
-.dialog-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
+  .cards-group { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .header-row { flex-direction: column; }
+  .search-wrapper { width: 100%; }
 }
 </style>

--- a/frontend/src/views/TrainingView.vue
+++ b/frontend/src/views/TrainingView.vue
@@ -8,7 +8,7 @@ import EmployeeTrainingView from './EmployeeTrainingView.vue'
 
 const auth = useAuthStore()
 const canSeeAll = computed(() =>
-  ['ADMIN', 'Leder', 'Styrer'].includes(auth.role ?? '')
+  ['ADMIN', 'MANAGER'].includes(auth.role ?? '')
 )
 </script>
 


### PR DESCRIPTION
This pull request introduces a complete backend implementation for managing staff training logs in the system. It adds a new database schema and seed data, domain model, repository, DTOs, service layer, and a REST API controller for CRUD operations on training logs. It also includes input validation, role-based access control, and OpenAPI documentation annotations.

The most important changes are:

**Database schema and data:**
* Added a new `training_logs` table with all relevant fields, foreign keys, and indexes to support training log management.
* Seeded the `training_logs` table with example data for development and testing purposes.

**Domain model and enums:**
* Introduced the `TrainingLog` JPA entity and the `TrainingStatus` enum to represent training log records and their status in the domain model. [[1]](diffhunk://#diff-20a4e2e11d7f17da5e18ef2dc21a0c5f5c3b9721e1f196d2ae7ba31a24a91099R1-R55) [[2]](diffhunk://#diff-7db5cb3b7f3faedbe763e34f1a766ff2d698ebba58dab936d0b5abcc95ef6e42R1-R8)

**Repository and DTOs:**
* Added `TrainingRepository` for database access and new DTOs for creating, updating, and returning training log data via the API. [[1]](diffhunk://#diff-48503bdb4b4a4939b45e4e3851981616d6aa26f7b36e8f3e6e9f95f883711259R1-R13) [[2]](diffhunk://#diff-48a07ab71e71f4f3940f96013211ee1a36d55d902cc3e7aaae08e3a573805781R1-R57)

**Service and business logic:**
* Implemented `TrainingService` with business logic for listing, retrieving, creating, updating, and deleting training logs, including validation and membership checks.

**REST API controller:**
* Added `TrainingController` exposing secured endpoints for managing training logs, with OpenAPI documentation and validation.

**Build process:**
* Updated the Docker build to run tests during the Maven package phase by removing the `-DskipTests` flag.